### PR TITLE
DE-8 - Cache GOCACHE content for multiple runs

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -36,6 +36,7 @@ jobs:
       # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies
         run: |
+          find /var/cache/apt
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc libsmbclient-dev
           find /tmp/gocache

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           find /var/cache/apt
-          find /tmp/gocache
+          find /tmp/gocache || true
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc libsmbclient-dev
           find /var/cache/apt

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -4,6 +4,8 @@ on:
     branches:
     - main
   pull_request:
+env:
+  GOCACHE: /tmp/gocache
 
 jobs:
   quality:
@@ -14,6 +16,23 @@ jobs:
       matrix:
         go: [ '1.15' ]
     steps:
+      - name: Cache GOCACHE
+        id: cache-gocache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: gocache-${{ github.job }}
+      - name: Cache APT
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/apt
+          key: apt-${{ github.job }}
+      - name: No Cache HIT?
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: echo "CACHE MISS"
+      - name: Cache HIT?
+        if: steps.go-cache.outputs.cache-hit == 'true'
+        run: echo "CACHE HIT"
       # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies
         run: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,31 +16,31 @@ jobs:
       matrix:
         go: [ '1.15' ]
     steps:
+      # As per https://github.com/actions/cache/issues/432#issuecomment-740376179 to workaround cache not being updated
+      # with the same name. We use the fallback property that will use the most recent cache matching the pattern, which
+      # ought to be the previous run, and then, will recache this with a new checksum.
+      # This should not be necessary if https://github.com/actions/cache/pull/498 is merged.
+      - name: Generate random cache key to ensure the cach directories are saved after build
+        id: random-cache-key
+        run: head /dev/random -c 32 > /tmp/random-cache-key
       - name: Cache GOCACHE
         id: cache-gocache
         uses: actions/cache@v2
         with:
           path: ${{ env.GOCACHE }}
-          key: gocache-${{ github.job }}-${{ hashFiles(${{ env.GOCACHE }}) }}
+          key: gocache-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
       - name: Cache APT
         uses: actions/cache@v2
         with:
           path: /var/cache/apt
-          key: apt-${{ github.job }}-${{ hashFiles('/var/cache/apt') }}
-      - name: No Cache HIT?
-        if: steps.cache-gocache.outputs.cache-hit != 'true'
-        run: echo "CACHE MISS"
-      - name: Cache HIT?
-        if: steps.cache-gocache.outputs.cache-hit == 'true'
-        run: echo "CACHE HIT"
+          key: apt-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
       # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies
         run: |
           find /var/cache/apt
+          find /tmp/gocache
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc libsmbclient-dev
-          find /tmp/gocache
-          echo "XXXXXXXXXXXXXXXXXXXX"
           find /var/cache/apt
       - uses: actions/checkout@v2
       - name: Setup go

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc libsmbclient-dev
+          find /tmp/gocache
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v2

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -29,11 +29,6 @@ jobs:
         with:
           path: ${{ env.GOCACHE }}
           key: gocache-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
-      - name: Cache APT
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/apt
-          key: apt-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
       # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies
         run: |
@@ -70,6 +65,15 @@ jobs:
       matrix:
         go: [ '1.15' ]
     steps:
+      - name: Generate random cache key to ensure the cach directories are saved after build
+        id: random-cache-key
+        run: head /dev/random -c 32 > /tmp/random-cache-key
+      - name: Cache GOCACHE
+        id: cache-gocache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: gocache-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v2
@@ -100,6 +104,15 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     steps:
+      - name: Generate random cache key to ensure the cach directories are saved after build
+        id: random-cache-key
+        run: head /dev/random -c 32 > /tmp/random-cache-key
+      - name: Cache GOCACHE
+        id: cache-gocache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: gocache-${{ github.job }}-${{ hashFiles('/tmp/random-cache-key') }}
       # Add dependencies
       - name: Install dependencies
         run: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -40,6 +40,8 @@ jobs:
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc libsmbclient-dev
           find /tmp/gocache
+          echo "XXXXXXXXXXXXXXXXXXXX"
+          find /var/cache/apt
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v2

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.GOCACHE }}
-          key: gocache-${{ github.job }}
+          key: gocache-${{ github.job }}-${{ hashFiles(${{ env.GOCACHE }}) }}
       - name: Cache APT
         uses: actions/cache@v2
         with:
           path: /var/cache/apt
-          key: apt-${{ github.job }}
+          key: apt-${{ github.job }}-${{ hashFiles('/var/cache/apt') }}
       - name: No Cache HIT?
         if: steps.cache-gocache.outputs.cache-hit != 'true'
         run: echo "CACHE MISS"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -28,10 +28,10 @@ jobs:
           path: /var/cache/apt
           key: apt-${{ github.job }}
       - name: No Cache HIT?
-        if: steps.go-cache.outputs.cache-hit != 'true'
+        if: steps.cache-gocache.outputs.cache-hit != 'true'
         run: echo "CACHE MISS"
       - name: Cache HIT?
-        if: steps.go-cache.outputs.cache-hit == 'true'
+        if: steps.cache-gocache.outputs.cache-hit == 'true'
         run: echo "CACHE HIT"
       # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies


### PR DESCRIPTION
This will speed up builds, tests and other CI checks by reusing and
single cache per job.
Note that the main cache is shared with new branches on PR. Then, the
local branch case is preferred.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>