### PR TITLE
Offline mode support

### DIFF
--- a/internal/policies/ad/export_test.go
+++ b/internal/policies/ad/export_test.go
@@ -9,6 +9,9 @@ var (
 func (ad *AD) GpoCacheDir() string {
 	return ad.gpoCacheDir
 }
+func (ad *AD) GpoRulesCacheDir() string {
+	return ad.gpoRulesCacheDir
+}
 func (ad *AD) Krb5CacheDir() string {
 	return ad.krb5CacheDir
 }

--- a/internal/policies/entry/entry.go
+++ b/internal/policies/entry/entry.go
@@ -17,7 +17,12 @@ type Entry struct {
 	Meta     string
 }
 
-// GPO is the GPO definition with all its parsed rules.
+const (
+	// GPORulesCacheBaseName is the base directory where we want to cache gpo rules
+	GPORulesCacheBaseName = "gpo_rules"
+)
+
+// GPO is a representation of a GPO with rules we support
 type GPO struct {
 	ID   string
 	Name string

--- a/internal/policies/policies.go
+++ b/internal/policies/policies.go
@@ -52,7 +52,7 @@ func New(opts ...option) (m *Manager, err error) {
 		}
 	}
 
-	gpoRulesCacheDir := filepath.Join(args.cacheDir, "gpo_rules")
+	gpoRulesCacheDir := filepath.Join(args.cacheDir, entry.GPORulesCacheBaseName)
 	if err := os.MkdirAll(gpoRulesCacheDir, 0700); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reload the gpo list and rules from cache if the first ad connection fails
(error 2) and that we have a local cache available.
Those are the rules which will be enforced for the object.
Add tests.
