### PR TITLE
Fix multi-lines support while dumping applied policies

### DIFF
--- a/cmd/adsysd/client/policy_test.go
+++ b/cmd/adsysd/client/policy_test.go
@@ -24,7 +24,7 @@ func TestColorizePolicies(t *testing.T) {
 Policies from user configuration:
 * GPOName3 ({GPOId2})
 ** dconf:
-***- path/to/key1: ValueOfKey1
+***- path/to/key1: ValueOfKey1\nOn\nMultilines
 ***- path/to/key2: ValueOfKey2
 ** scripts:
 ***-+ path/to/key3

--- a/cmd/adsysd/client/testdata/golden/colorize.golden
+++ b/cmd/adsysd/client/testdata/golden/colorize.golden
@@ -12,7 +12,7 @@
 [1m[94mPolicies from user configuration:[0m[0m
 - [35mGPOName3[0m ({GPOId2})
     - [1mdconf:[0m
-[90m        - path/to/key1: ValueOfKey1[0m
+[90m        - path/to/key1: ValueOfKey1\nOn\nMultilines[0m
 [90m        - path/to/key2: ValueOfKey2[0m
     - [1mscripts:[0m
 [90m        - path/to/key3: Locked to system default[0m

--- a/internal/policies/entry/entry.go
+++ b/internal/policies/entry/entry.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/ubuntu/adsys/internal/decorate"
 	"github.com/ubuntu/adsys/internal/i18n"
@@ -101,7 +102,8 @@ func (g GPO) FormatGPO(w io.Writer, withRules, withOverridden bool, alreadyProce
 			if overr {
 				prefix += "-"
 			}
-			v := r.Value
+			// Trim EOL \n and replace them all with \n in text to keep each value printed in one single line
+			v := strings.ReplaceAll(strings.TrimSpace(r.Value), "\n", `\n`)
 			if r.Disabled {
 				prefix += "+"
 				fmt.Fprintf(w, "%s %s\n", prefix, r.Key)

--- a/internal/policies/entry/testdata/golden/GPO with rules
+++ b/internal/policies/entry/testdata/golden/GPO with rules
@@ -1,6 +1,6 @@
 * GPOName ({GPOId})
 ** dconf:
 *** path/to/key1: ValueOfKey1
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***+ path/to/key3

--- a/internal/policies/entry/testdata/golden/GPO with rules and overrides, no rules processed
+++ b/internal/policies/entry/testdata/golden/GPO with rules and overrides, no rules processed
@@ -1,6 +1,6 @@
 * GPOName ({GPOId})
 ** dconf:
 *** path/to/key1: ValueOfKey1
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***+ path/to/key3

--- a/internal/policies/entry/testdata/golden/GPO with rules, appending to existing treated key
+++ b/internal/policies/entry/testdata/golden/GPO with rules, appending to existing treated key
@@ -1,6 +1,6 @@
 * GPOName ({GPOId})
 ** dconf:
 *** path/to/key1: ValueOfKey1
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***+ path/to/key3

--- a/internal/policies/entry/testdata/golden/GPO with rules, override disabled key
+++ b/internal/policies/entry/testdata/golden/GPO with rules, override disabled key
@@ -1,6 +1,6 @@
 * GPOName ({GPOId})
 ** dconf:
 *** path/to/key1: ValueOfKey1
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***-+ path/to/key3

--- a/internal/policies/entry/testdata/golden/GPO with rules, override displayed
+++ b/internal/policies/entry/testdata/golden/GPO with rules, override displayed
@@ -1,6 +1,6 @@
 * GPOName ({GPOId})
 ** dconf:
 ***- path/to/key1: ValueOfKey1
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***+ path/to/key3

--- a/internal/policies/entry/testdata/golden/GPO with rules, override hidden
+++ b/internal/policies/entry/testdata/golden/GPO with rules, override hidden
@@ -1,5 +1,5 @@
 * GPOName ({GPOId})
 ** dconf:
-*** path/to/key2: ValueOfKey2
+*** path/to/key2: ValueOfKey2\nOn\nMultilines
 ** scripts:
 ***+ path/to/key3

--- a/internal/policies/entry/testdata/gpos.cache
+++ b/internal/policies/entry/testdata/gpos.cache
@@ -6,7 +6,10 @@
       value: ValueOfKey1
       meta: s
     - key: path/to/key2
-      value: ValueOfKey2
+      value: |
+        ValueOfKey2
+        On
+        Multilines
       meta: s
     scripts:
     - key: path/to/key3


### PR DESCRIPTION
Multi-lines values were kept as multi-lines, breaking colorization and
making it hard to read.
Keep everything in a single line with \n.