### PR TITLE
Changed namespece to Ubuntu in admx files

### DIFF
--- a/internal/policies/ad/admxgen/admx.template
+++ b/internal/policies/ad/admxgen/admx.template
@@ -2,8 +2,8 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 

--- a/internal/policies/ad/admxgen/defs/categories.yaml
+++ b/internal/policies/ad/admxgen/defs/categories.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.04
 categories:
   - displayname: "Ubuntu"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "User"
     children:
     - displayname: "Desktop"

--- a/internal/policies/ad/admxgen/testdata/admx/admx generation fails.yaml
+++ b/internal/policies/ad/admxgen/testdata/admx/admx generation fails.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/com/ubuntu/simple/simple-text-property"

--- a/internal/policies/ad/admxgen/testdata/admx/autodetect overrides releases from yaml.yaml
+++ b/internal/policies/ad/admxgen/testdata/admx/autodetect overrides releases from yaml.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/com/ubuntu/simple/simple-text-property"

--- a/internal/policies/ad/admxgen/testdata/admx/category expansion fails.yaml
+++ b/internal/policies/ad/admxgen/testdata/admx/category expansion fails.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/key/does/not/exists"

--- a/internal/policies/ad/admxgen/testdata/admx/golden/autodetect overrides releases from yaml-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/admx/golden/autodetect overrides releases from yaml-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/admx/golden/releases from yaml-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/admx/golden/releases from yaml-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/admx/releases from yaml.yaml
+++ b/internal/policies/ad/admxgen/testdata/admx/releases from yaml.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/com/ubuntu/simple/simple-text-property"

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/array of integers.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/array of integers.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-array-decimal
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/array of strings.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/array of strings.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-array-string
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/boolean.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/boolean.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-boolean
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/choices with default.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/choices with default.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-choices
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/choices.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/choices.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-choices
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with max only.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with max only.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-decimal-with-range
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with min only.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with min only.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-decimal-with-range
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with range.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal with range.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-decimal-with-range
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/decimal.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-decimal
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/double with range.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/double with range.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-double
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/double.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/double.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-double
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/error on destination creation.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/error on destination creation.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/long decimal.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/long decimal.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-long-decimal
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple categories.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple categories.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-multiple1
     explaintext: |-
@@ -27,7 +27,7 @@
 
 
 - displayname: Category2 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-multiple2
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases for one key.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases for one key.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with all widgets and different defaults.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with all widgets and different defaults.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different choices.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different choices.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different ranges.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different ranges.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different widgettype.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/multiple releases with different widgettype.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/nested categories.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/nested categories.yaml
@@ -1,5 +1,5 @@
 - displayname: Parent Category Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-first
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/other distro.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/other distro.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/simple.yaml
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/defs/simple.yaml
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/array of integers-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/array of integers-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/array of strings-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/array of strings-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/boolean-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/boolean-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/choices with default-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/choices with default-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/choices-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/choices-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with max only-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with max only-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with min only-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with min only-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with range-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal with range-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/decimal-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/double with range-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/double with range-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/double-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/double-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/long decimal-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/long decimal-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple categories-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple categories-Ubuntu.admx
@@ -2,17 +2,17 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
     <category name="UbuntuCategory2DisplayName" displayName="$(string.UbuntuDisplayCategory2DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases for one key-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases for one key-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with all widgets and different defaults-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with all widgets and different defaults-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different choices-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different choices-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different ranges-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different ranges-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different widgettype-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/multiple releases with different widgettype-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/nested categories-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/nested categories-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuParentCategoryDisplayName" displayName="$(string.UbuntuDisplayParentCategoryDisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
     <category name="UbuntuChildCategoryDisplayName" displayName="$(string.UbuntuDisplayChildCategoryDisplayName)">
       <parentCategory ref="UbuntuParentCategoryDisplayName" />

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/other distro-Debian.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/other distro-Debian.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="DebianCategory1DisplayName" displayName="$(string.DebianDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/simple-Ubuntu.admx
+++ b/internal/policies/ad/admxgen/testdata/expandedCategoriesToADMX/golden/simple-Ubuntu.admx
@@ -2,14 +2,14 @@
 <!--  (c) 2021 Canonical  -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
-    <target prefix="desktop" namespace="Microsoft.Policies.WindowsDesktop" />
-    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+    <target prefix="ubuntudesktop" namespace="Canonical.Policies.UbuntuDesktop" />
+    <using prefix="ubuntu" namespace="Canonical.Policies.Ubuntu" />
   </policyNamespaces>
   <resources minRequiredRevision="1.0" />
 
   <categories>
     <category name="UbuntuCategory1DisplayName" displayName="$(string.UbuntuDisplayCategory1DisplayName)">
-      <parentCategory ref="windows:Desktop" />
+      <parentCategory ref="ubuntu:Desktop" />
     </category>
   </categories>
 

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/available on one release only.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/available on one release only.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/choices.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/choices.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-choices"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/default policy class is capitalized.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/default policy class is capitalized.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different choices.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different choices.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-choices"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different defaults.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different defaults.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different display name.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different display name.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different element type.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different element type.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different explain text.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different explain text.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different meta.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different meta.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different range.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/different range.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on different class.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on different class.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on different policy type.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on different policy type.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on empty default policy class.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on empty default policy class.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: ""
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on invalid default policy class.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on invalid default policy class.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Invalid Class"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on missing release.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on missing release.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on nested category.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on nested category.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Parent Category Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-first"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on one policy not used.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on one policy not used.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-first"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on policy not attached to any releases.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on policy not attached to any releases.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on unexisting policy referenced.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/error on unexisting policy referenced.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/multiple top categories.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/multiple top categories.yaml
@@ -3,12 +3,12 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category 1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-first"
   - displayname: "Category 2 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-second"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/nested categories.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/nested categories.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Parent Category Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-first"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/policy directory doesn't exist.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/policy directory doesn't exist.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/range.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/range.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-range"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same default.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same default.yaml
@@ -4,7 +4,7 @@ supportedreleases:
   - 21.10
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-common"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same policy used in two categories but different default class.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same policy used in two categories but different default class.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Parent Category Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same policy used in two categories.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/same policy used in two categories.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Parent Category Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/simple.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/simple.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-simple"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/two policies.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/two policies.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-first"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/use policy class instead of category default.yaml
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/defs/use policy class instead of category default.yaml
@@ -3,7 +3,7 @@ supportedreleases:
   - 20.04
 categories:
   - displayname: "Category1 Display Name"
-    parent: "windows:Desktop"
+    parent: "ubuntu:Desktop"
     defaultpolicyclass: "Machine"
     policies:
       - "/org/gnome/desktop/policy-with-class"

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/available on one release only
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/available on one release only
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/choices
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/choices
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-choices
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/default policy class is capitalized
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/default policy class is capitalized
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different choices
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different choices
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-choices
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different defaults
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different defaults
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different display name
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different display name
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different element type
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different element type
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different explain text
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different explain text
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different meta
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different meta
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different policy type
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different policy type
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Ubuntu\notdconf\org\gnome\desktop\policy-common
     displayname: summary common

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different range
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/different range
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/multiple top categories
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/multiple top categories
@@ -1,5 +1,5 @@
 - displayname: Category 1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-first
     explaintext: |-
@@ -26,7 +26,7 @@
         release: "20.04"
         type: dconf
 - displayname: Category 2 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-second
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/nested categories
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/nested categories
@@ -1,5 +1,5 @@
 - displayname: Parent Category Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-first
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property available on one release only
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property available on one release only
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Ubuntu\dconf\org\gnome\desktop\policy-common
     displayname: summary common

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property with different defaults
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property with different defaults
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Ubuntu\dconf\org\gnome\desktop\policy-common
     displayname: summary common

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property with same default
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/one property with same default
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Ubuntu\dconf\org\gnome\desktop\policy-first
     displayname: summary first

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/range
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/range
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-range
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same default
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same default
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-common
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same policy used in two categories
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same policy used in two categories
@@ -1,5 +1,5 @@
 - displayname: Parent Category Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same policy used in two categories but different default class
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/same policy used in two categories but different default class
@@ -1,5 +1,5 @@
 - displayname: Parent Category Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/simple
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/simple
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-simple
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/two policies
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/two policies
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-first
     explaintext: |-

--- a/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/use policy class instead of category default
+++ b/internal/policies/ad/admxgen/testdata/generateExpandedCategories/golden/use policy class instead of category default
@@ -1,5 +1,5 @@
 - displayname: Category1 Display Name
-  parent: windows:Desktop
+  parent: ubuntu:Desktop
   policies:
   - key: Software\Policies\Ubuntu\dconf\org\gnome\desktop\policy-with-class
     explaintext: |-


### PR DESCRIPTION
this avoids conflicts with Windows namespace when Ubuntu templates are
deployed alongside Windows template in the central store.

Co-authored-by: Didier Roche <didrocks@ubuntu.com>