### PR TITLE
Depends on sssd offline status to try fetching the GPOs

### DIFF
--- a/cmd/integration_tests/adsysctl_policy_test.go
+++ b/cmd/integration_tests/adsysctl_policy_test.go
@@ -408,8 +408,8 @@ func TestPolicyUpdate(t *testing.T) {
 			initState: "old-data",
 			// clean generate dconf dbs to regenerate
 			clearDirs: []string{
-				"dconf/db/adsystestuser@example.com.d",
-				"dconf/profile/adsystestuser@example.com",
+				"dconf/db/adsystestuser@offline.d",
+				"dconf/profile/adsystestuser@offline",
 			},
 			krb5ccNamesState: []krb5ccNamesWithState{
 				{
@@ -428,8 +428,8 @@ func TestPolicyUpdate(t *testing.T) {
 			initState: "old-data",
 			// clean gpos cache, but keep machine ones and user gpo_rules
 			clearDirs: []string{
-				"dconf/db/adsystestuser@example.com.d",
-				"dconf/profile/adsystestuser@example.com",
+				"dconf/db/adsystestuser@offline.d",
+				"dconf/profile/adsystestuser@offline",
 				"cache/gpo_cache/{5EC4DF8F-FF4E-41DE-846B-52AA6FFAF242}",
 				"cache/gpo_cache/{073AA7FC-5C1A-4A12-9AFC-42EC9C5CAF04}",
 				"cache/gpo_cache/{75545F76-DEC2-4ADA-B7B8-D5209FD48727}",
@@ -777,7 +777,7 @@ func TestPolicyUpdate(t *testing.T) {
 			if tc.isOffLine {
 				content, err := os.ReadFile(conf)
 				require.NoError(t, err, "Setup: can’t read configuration file")
-				content = bytes.Replace(content, []byte("ldap://adc.example.com"), []byte("ldap://NT_STATUS_HOST_UNREACHABLE"), 1)
+				content = bytes.Replace(content, []byte("ad_domain: example.com"), []byte("ad_domain: offline"), 1)
 				err = os.WriteFile(conf, content, 0644)
 				require.NoError(t, err, "Setup: can’t rewrite configuration file")
 			}

--- a/cmd/integration_tests/adsysctl_service_test.go
+++ b/cmd/integration_tests/adsysctl_service_test.go
@@ -312,7 +312,7 @@ func TestServiceStatus(t *testing.T) {
 			if tc.isOffLine {
 				content, err := os.ReadFile(conf)
 				require.NoError(t, err, "Setup: can’t read configuration file")
-				content = bytes.Replace(content, []byte("ldap://adc.example.com"), []byte("ldap://NT_STATUS_HOST_UNREACHABLE"), 1)
+				content = bytes.Replace(content, []byte("ad_domain: example.com"), []byte("ad_domain: offline"), 1)
 				err = os.WriteFile(conf, content, 0644)
 				require.NoError(t, err, "Setup: can’t rewrite configuration file")
 			}

--- a/cmd/integration_tests/systemdaemons/Dockerfile
+++ b/cmd/integration_tests/systemdaemons/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 
-COPY cmd/adsysd/integration_tests/systemdaemons/dbus.conf /
-COPY cmd/adsysd/integration_tests/systemdaemons/systemdaemons.sh /
+COPY cmd/integration_tests/systemdaemons/dbus.conf /
+COPY cmd/integration_tests/systemdaemons/systemdaemons.sh /
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN \

--- a/cmd/integration_tests/systemdaemons/build.sh
+++ b/cmd/integration_tests/systemdaemons/build.sh
@@ -8,4 +8,4 @@ set -eu
 
 rootdir="$(realpath $(dirname $(realpath $0))/../../../)"
 cd ${rootdir}
-docker build -t docker.pkg.github.com/ubuntu/adsys/systemdaemons:0.1 -f cmd/adsysd/integration_tests/systemdaemons/Dockerfile .
+docker build -t docker.pkg.github.com/ubuntu/adsys/systemdaemons:0.1 -f cmd/integration_tests/systemdaemons/Dockerfile .

--- a/cmd/integration_tests/systemdaemons/dbus.conf
+++ b/cmd/integration_tests/systemdaemons/dbus.conf
@@ -62,4 +62,13 @@
     <allow send_destination="org.freedesktop.systemd1"/>
   </policy>
 
+  <!-- sssd config -->
+  <policy user="root">
+    <allow own="org.freedesktop.sssd.infopipe"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="org.freedesktop.sssd.infopipe"/>
+  </policy>
+
 </busconfig>

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status offline cache
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status offline cache
@@ -7,8 +7,8 @@ Connected users:
 Next Refresh: Tue May 25 14:55
 
 Active Directory:
-  Server: ldap://NT_STATUS_HOST_UNREACHABLE
-  Domain: example.com
+  Server: ldap://adc.example.com
+  Domain: offline
 
 SSS:
   Configuration: /etc/sssd/sssd.conf

--- a/internal/adsysservice/adsysservice.go
+++ b/internal/adsysservice/adsysservice.go
@@ -161,7 +161,7 @@ func New(ctx context.Context, url, domain string, opts ...option) (s *Service, e
 	if args.sssCacheDir != "" {
 		adOptions = append(adOptions, ad.WithSSSCacheDir(args.sssCacheDir))
 	}
-	adc, err := ad.New(ctx, url, domain, adOptions...)
+	adc, err := ad.New(ctx, url, domain, bus, adOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adsysservice/adsysservice.go
+++ b/internal/adsysservice/adsysservice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -138,9 +139,9 @@ func New(ctx context.Context, url, domain string, opts ...option) (s *Service, e
 	// Try sssd discovered ad server url
 	if url == "" {
 		log.Debug(ctx, "AD server not specified in sssd.conf nor set manually to the user, try autodiscovering mode")
-		sssd := bus.Object("org.freedesktop.sssd.infopipe",
-			dbus.ObjectPath(fmt.Sprintf("/org/freedesktop/sssd/infopipe/Domains/%s", strings.ReplaceAll(domain, ".", "_2e"))))
-		if err := sssd.Call("org.freedesktop.sssd.infopipe.Domains.Domain.ActiveServer", 0, "AD").Store(&url); err != nil || url == "" {
+		sssd := bus.Object(consts.SSSDDbusRegisteredName,
+			dbus.ObjectPath(filepath.Join(consts.SSSDDbusBaseObjectPath, strings.ReplaceAll(domain, ".", "_2e"))))
+		if err := sssd.Call(consts.SSSDDbusInterface+".ActiveServer", 0, "AD").Store(&url); err != nil || url == "" {
 			return nil, errors.New(i18n.G("failed to find active AD server address in sssd (sssd.conf or sssd discovery) and url is not provided"))
 		}
 	}

--- a/internal/adsysservice/adsysservice_test.go
+++ b/internal/adsysservice/adsysservice_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/adsys/internal/adsysservice"
 	"github.com/ubuntu/adsys/internal/authorizer"
+	"github.com/ubuntu/adsys/internal/testutils"
 )
 
 type mockAuthorizer struct {
@@ -38,7 +39,7 @@ func TestNew(t *testing.T) {
 			</method>
 		</interface>` + introspect.IntrospectDataString + `</node>`
 
-	conn := newDbusConn(t)
+	conn := testutils.NewDbusConn(t)
 	sssdDomain := sssd("my-discovered-url")
 	conn.Export(sssdDomain, "/org/freedesktop/sssd/infopipe/Domains/fordiscovery_2ecom", "org.freedesktop.sssd.infopipe.Domains.Domain")
 	conn.Export(introspect.Introspectable(intro), "/org/freedesktop/sssd/infopipe/Domains/fordiscovery_2ecom",
@@ -127,23 +128,4 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err, "adsys run directory exists as expected")
 		})
 	}
-}
-
-// newDbusConn returns a system dbus connection which will be tore down when tests ends
-func newDbusConn(t *testing.T) *dbus.Conn {
-	t.Helper()
-
-	bus, err := dbus.SystemBusPrivate()
-	require.NoError(t, err, "Setup: can’t get a private system bus")
-
-	t.Cleanup(func() {
-		err = bus.Close()
-		require.NoError(t, err, "Teardown: can’t close system dbus connection")
-	})
-	err = bus.Auth(nil)
-	require.NoError(t, err, "Setup: can’t auth on private system bus")
-	err = bus.Hello()
-	require.NoError(t, err, "Setup: can’t send hello message on private system bus")
-
-	return bus
 }

--- a/internal/authorizer/authorizer_test.go
+++ b/internal/authorizer/authorizer_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/ubuntu/adsys/internal/authorizer"
+	"github.com/ubuntu/adsys/internal/testutils"
 	"google.golang.org/grpc/peer"
 )
 
 func TestIsAllowedFromContext(t *testing.T) {
 	t.Parallel()
 
-	bus := authorizer.NewDbusConn(t)
+	bus := testutils.NewDbusConn(t)
 
 	var emptyAction authorizer.Action
 	simpleAction := authorizer.Action{
@@ -91,7 +92,7 @@ func TestIsAllowedFromContext(t *testing.T) {
 
 func TestIsAllowedFromContextWithoutPeer(t *testing.T) {
 	t.Parallel()
-	bus := authorizer.NewDbusConn(t)
+	bus := testutils.NewDbusConn(t)
 
 	a, err := authorizer.New(bus)
 	if err != nil {
@@ -104,7 +105,7 @@ func TestIsAllowedFromContextWithoutPeer(t *testing.T) {
 
 func TestIsAllowedFromContextWithInvalidPeerCreds(t *testing.T) {
 	t.Parallel()
-	bus := authorizer.NewDbusConn(t)
+	bus := testutils.NewDbusConn(t)
 
 	a, err := authorizer.New(bus)
 	if err != nil {
@@ -122,7 +123,7 @@ func TestIsAllowedFromContextWithInvalidPeerCreds(t *testing.T) {
 
 func TestIsAllowedFromContextWithoutUserKey(t *testing.T) {
 	t.Parallel()
-	bus := authorizer.NewDbusConn(t)
+	bus := testutils.NewDbusConn(t)
 
 	myUserOtherAction := authorizer.Action{
 		ID:      "UserOtherActionID",

--- a/internal/authorizer/internal_test.go
+++ b/internal/authorizer/internal_test.go
@@ -11,16 +11,14 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/ubuntu/adsys/internal/testutils"
 )
 
 func TestIsAllowed(t *testing.T) {
 	t.Parallel()
 
-	bus := NewDbusConn(t)
+	bus := testutils.NewDbusConn(t)
 
 	var emptyAction Action
 	simpleAction := Action{
@@ -167,25 +165,6 @@ func TestServerPeerCredsInvalidSocket(t *testing.T) {
 
 	s := serverPeerCreds{}
 	s.ServerHandshake(nil)
-}
-
-// NewDbusConn returns a system dbus connection which will be tore down when tests ends
-func NewDbusConn(t *testing.T) *dbus.Conn {
-	t.Helper()
-
-	bus, err := dbus.SystemBusPrivate()
-	require.NoError(t, err, "Setup: can’t get a private system bus")
-
-	t.Cleanup(func() {
-		err = bus.Close()
-		require.NoError(t, err, "Teardown: can’t close system dbus connection")
-	})
-	err = bus.Auth(nil)
-	require.NoError(t, err, "Setup: can’t auth on private system bus")
-	err = bus.Hello()
-	require.NoError(t, err, "Setup: can’t send hello message on private system bus")
-
-	return bus
 }
 
 func TestMain(m *testing.M) {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -24,13 +24,6 @@ const (
 	// DefaultRunDir is the default path for adsys run directory
 	DefaultRunDir = "/run/adsys"
 
-	// DefaultSSSCacheDir is the default sssd cache dir
-	DefaultSSSCacheDir = "/var/lib/sss/db"
-	// DefaultSSSConf is the default sssd.conf location
-	DefaultSSSConf = "/etc/sssd/sssd.conf"
-	// DefaultDconfDir is the default dconf directory
-	DefaultDconfDir = "/etc/dconf"
-
 	// DefaultClientTimeout is the maximum default time in seconds between 2 server activities before the client returns and abort the request.
 	DefaultClientTimeout = 30
 
@@ -39,4 +32,19 @@ const (
 
 	// DistroID is the distro ID which can be overridden at build time
 	DistroID = "Ubuntu"
+
+	// SSSD related properties
+	// DefaultSSSCacheDir is the default sssd cache dir
+	DefaultSSSCacheDir = "/var/lib/sss/db"
+	// DefaultSSSConf is the default sssd.conf location
+	DefaultSSSConf = "/etc/sssd/sssd.conf"
+	// DefaultDconfDir is the default dconf directory
+	DefaultDconfDir = "/etc/dconf"
+
+	// SSSDDbusRegisteredName is the well-known name used on dbus
+	SSSDDbusRegisteredName = "org.freedesktop.sssd.infopipe"
+	// SSSDDbusBaseObjectPath is the path under which all domains are registered
+	SSSDDbusBaseObjectPath = "/org/freedesktop/sssd/infopipe/Domains"
+	// SSSDDbusInterface is the interface we are using for access dbus methods
+	SSSDDbusInterface = "org.freedesktop.sssd.infopipe.Domains.Domain"
 )

--- a/internal/policies/ad/ad.go
+++ b/internal/policies/ad/ad.go
@@ -212,7 +212,7 @@ func (ad *AD) GetPolicies(ctx context.Context, objectName string, objectClass Ob
 	ad.Unlock()
 
 	// If sssd returns that we are offline, returns the cache list of GPOs if present
-	if ad.IsOffline {
+	if !online {
 		if r, err = entry.NewGPOs(filepath.Join(ad.gpoRulesCacheDir, objectName)); err != nil {
 			return nil, fmt.Errorf(i18n.G("machine is offline and GPO rules cache is unavailable: %v"), err)
 		}


### PR DESCRIPTION
- request to sssd in what status we are in
- if we are online, do the samba/ldap requests as we used to do, but with a contextual timeout.
Do not use gpolist status returned code for determining if we are offline or not. Only base our state on sssd as this is what logged it in or not.
We are doing the request everytime we want to download the GPO list, as sssd will flip status based on network connectivity change.

Note that sssd doesn’t always flip the state when going back offline having no network connected. In that case. we let gpo list script failing (either exit 2 or timing out). This will be the case only for refreshes, and the machine is already offline, but wrongly reported online. Keep thus last known good state and report the failure in logs.