### PR TITLE
TestServiceStatus: changed settings path

### DIFF
--- a/cmd/integration_tests/adsysctl_service_test.go
+++ b/cmd/integration_tests/adsysctl_service_test.go
@@ -363,8 +363,8 @@ func TestServiceStatus(t *testing.T) {
 			require.NoError(t, err, "client should exit with no error")
 
 			// Make paths suitable for golden recording and comparison
-			re := regexp.MustCompile(`_.*/`)
-			got = re.ReplaceAllString(got, "_XXXXXX/")
+			re := regexp.MustCompile(`/tmp/.*/`)
+			got = re.ReplaceAllString(got, "/tmp/")
 
 			re = regexp.MustCompile(`(updated on)([^\n]*)`)
 			got = re.ReplaceAllString(got, "$1 DDD MON D HH:MM")

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Invalid startup time leads to unknown refresh time
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Invalid startup time leads to unknown refresh time
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Invalid unit refresh time leads to unknown refresh time
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Invalid unit refresh time leads to unknown refresh time
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/No startup time leads to unknown refresh time
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/No startup time leads to unknown refresh time
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/No unit refresh time leads to unknown refresh time
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/No unit refresh time leads to unknown refresh time
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status is always authorized
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status is always authorized
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status no user connected and no machine
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status no user connected and no machine
@@ -9,11 +9,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status offline cache
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status offline cache
@@ -12,11 +12,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status on user connected with no cache
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status on user connected with no cache
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status with dynamic AD server
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status with dynamic AD server
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status with empty dynamic AD server
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status with empty dynamic AD server
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf

--- a/cmd/integration_tests/testdata/PolicyStatus/golden/Status with users and machines
+++ b/cmd/integration_tests/testdata/PolicyStatus/golden/Status with users and machines
@@ -10,11 +10,11 @@ Active Directory:
 
 SSS:
   Configuration: /etc/sssd/sssd.conf
-  Cache directory: /tmp/TestServiceStatus_XXXXXX/sss_cache
+  Cache directory: /tmp/sss_cache
 
 Daemon:
   Timeout after 30s
-  Listening on: /tmp/TestServiceStatus_XXXXXX/socket
-  Cache path: /tmp/TestServiceStatus_XXXXXX/cache
-  Run path: /tmp/TestServiceStatus_XXXXXX/run
-  Dconf path: /tmp/TestServiceStatus_XXXXXX/dconf
+  Listening on: /tmp/socket
+  Cache path: /tmp/cache
+  Run path: /tmp/run
+  Dconf path: /tmp/dconf


### PR DESCRIPTION
The behaviour of Test.Tempdir changed in go 1.17 and now include the
name of the test and the name of the subtest. As a consequence the
golden files are different between 1.16 and 1.17 and TestServiceStatus
cannot run on both. We now strip entirely the name of the test from the
output file.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>