### PR TITLE
Workaround CI adm generation failing on impish

### DIFF
--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -82,7 +82,7 @@ jobs:
 
   collect-releases:
     name: Collect supported keys on each releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs:
       - build-admxgen
       - supported-releases

--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -99,7 +99,8 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt update
-          apt -y install ubuntu-desktop
+          # Ignore installation error, we will remove the PR anyway if anything is missing
+          apt -y install ubuntu-desktop || true
       - name: Collect support keys
         run: |
           chmod 755 ./admxgen


### PR DESCRIPTION
ibus can’t be setup in the container, let’s ignore install failure.
We will review the PR anyway if anything is generated and it not
expected.