### PR TITLE
Refresh golden test files with latest dconf changes

### DIFF
--- a/internal/policies/ad/admxgen/dconf/testdata/golden/description_containing_deprecated_without_starting_by_it_is_not_ignored
+++ b/internal/policies/ad/admxgen/dconf/testdata/golden/description_containing_deprecated_without_starting_by_it_is_not_ignored
@@ -6,6 +6,7 @@
     empty: ''''''
     meta: s
   default: '''simple-text-property Default Value'''
+  note: default system value is used for "Not Configured" and enforced if "Disabled".
   release: "20.04"
   type: dconf
 - key: /com/ubuntu/with-deprecated/deprecated-in-middle
@@ -16,5 +17,6 @@
     empty: ''''''
     meta: s
   default: '''deprecated-in-middle Default Value'''
+  note: default system value is used for "Not Configured" and enforced if "Disabled".
   release: "20.04"
   type: dconf

--- a/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_deprecated_is_ignored
+++ b/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_deprecated_is_ignored
@@ -6,5 +6,6 @@
     empty: ''''''
     meta: s
   default: '''simple-text-property Default Value'''
+  note: default system value is used for "Not Configured" and enforced if "Disabled".
   release: "20.04"
   type: dconf

--- a/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_deprecated_mixed_case_is_ignored
+++ b/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_deprecated_mixed_case_is_ignored
@@ -6,5 +6,6 @@
     empty: ''''''
     meta: s
   default: '''simple-text-property Default Value'''
+  note: default system value is used for "Not Configured" and enforced if "Disabled".
   release: "20.04"
   type: dconf

--- a/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_obsolete_is_ignored
+++ b/internal/policies/ad/admxgen/dconf/testdata/golden/description_starting_with_obsolete_is_ignored
@@ -6,5 +6,6 @@
     empty: ''''''
     meta: s
   default: '''simple-text-property Default Value'''
+  note: default system value is used for "Not Configured" and enforced if "Disabled".
   release: "20.04"
   type: dconf


### PR DESCRIPTION
Now that we add notes to dconf object, refresh golden files to add it.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>