### PR TITLE
Migrate to new grpc API for insecure credentials

### DIFF
--- a/cmd/integration_tests/adsys_test.go
+++ b/cmd/integration_tests/adsys_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Integration tests skipped as requested")
 		return
 	}
+
 	// Start 2 containers running local polkitd with our policy (one for always yes, one for always no)
 	// We only start samba on non helper process
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
@@ -360,7 +361,7 @@ func runDaemons() (teardown func()) {
 			out, _ := cmd.CombinedOutput()
 			// Docker stop -t 0 will kill it anyway the container with exit code 143
 			if cmd.ProcessState.ExitCode() > 0 && cmd.ProcessState.ExitCode() != 143 {
-				log.Fatalf("Error running system daemons %s container: %v", answer, string(out))
+				log.Fatalf("Error running system daemons container named %q:\n%v", answer, string(out))
 			}
 		}()
 	}
@@ -370,7 +371,7 @@ func runDaemons() (teardown func()) {
 	}
 
 	// give time for polkit containers to start
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	return func() {
 		defer func() {

--- a/cmd/integration_tests/systemdaemons/systemdaemons.sh
+++ b/cmd/integration_tests/systemdaemons/systemdaemons.sh
@@ -23,7 +23,7 @@ fi
 # Add dbus registername main objects
 python3 -m dbusmock --system org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager &
 python3 -m dbusmock --system org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Domains/example_2ecom org.freedesktop.sssd.infopipe.Domains.Domain &
-sleep 1
+sleep 3
 
 # Handle systemd objects depending on the mode
 time=""

--- a/internal/adsysservice/client.go
+++ b/internal/adsysservice/client.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // AdSysClient is a wrapper around a grpc service client which can close the underlying connection.
@@ -24,7 +25,7 @@ type AdSysClient struct {
 func NewClient(socket string, timeout time.Duration) (c *AdSysClient, err error) {
 	defer decorate.OnError(&err, i18n.G("can't create client for service"))
 
-	conn, err := grpc.Dial(fmt.Sprintf("unix:%s", socket), grpc.WithInsecure(),
+	conn, err := grpc.Dial(fmt.Sprintf("unix:%s", socket), grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStreamInterceptor(interceptorschain.StreamClient(
 			log.StreamClientInterceptor(logrus.StandardLogger()),
 			// This is the last element which will be the first interceptor to execute to get all pings.


### PR DESCRIPTION
As we are using a local unix socket, the rights are processed at the
kernel groups level.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>