### PR TITLE
Fix panic on some machine with zip implementation when relSrc is empty.

### DIFF
--- a/internal/policies/policies.go
+++ b/internal/policies/policies.go
@@ -215,6 +215,10 @@ func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string) (err e
 	// zip doesn’t like final /, even when listing them return it.
 	relSrc = strings.TrimSuffix(relSrc, "/")
 
+	if relSrc == "" {
+		return errors.New(i18n.G("no relSrc provided to look into database archive"))
+	}
+
 	dstPath := filepath.Join(dest, strings.TrimPrefix(relSrc, baseDir))
 
 	f, err := pols.assets.Open(relSrc)


### PR DESCRIPTION
The test was failing on my machine.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>