### PR TITLE
We can now have test-only packages.

### DIFF
--- a/cmd/integration_tests/workaround.go
+++ b/cmd/integration_tests/workaround.go
@@ -1,5 +1,0 @@
-package adsys
-
-/*
-This file exists to work around https://github.com/golang/go/issues/27333
-*/


### PR DESCRIPTION
No need for workaround anymore since Go 1.16.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>