### PR TITLE
Fix chown scripts

### DIFF
--- a/internal/ad/ad_test.go
+++ b/internal/ad/ad_test.go
@@ -682,7 +682,7 @@ func TestGetPolicies(t *testing.T) {
 			// Compare assets
 			uncompressedAssets := t.TempDir()
 			require.NoError(t, os.RemoveAll(uncompressedAssets), "Teardown: can’t remove uncompressed assets directory for saving assets")
-			err = entries.SaveAssetsTo(context.Background(), ".", uncompressedAssets)
+			err = entries.SaveAssetsTo(context.Background(), ".", uncompressedAssets, -1, -1)
 			if tc.wantAssetsEquals == "" {
 				require.Error(t, err, "Teardown: policies should have no assets to uncompress")
 				require.NoFileExists(t, filepath.Join(adc.SysvolCacheDir(), "assets.db"), "assets db cache should not exists")
@@ -1306,8 +1306,8 @@ func assertEqualPolicies(t *testing.T, expected policies.Policies, got policies.
 	require.NoError(t, os.RemoveAll(expectedAssetsDir), "Teardown: can’t remove expected assets directory created for comparison")
 	require.NoError(t, os.RemoveAll(gotAssetsDir), "Teardown: can’t remove new assets directory created for comparison")
 
-	require.NoError(t, expected.SaveAssetsTo(context.Background(), ".", expectedAssetsDir), "Teardown: Saving expected policies failed.")
-	require.NoError(t, got.SaveAssetsTo(context.Background(), ".", gotAssetsDir), "Teardown: Saving got policies failed.")
+	require.NoError(t, expected.SaveAssetsTo(context.Background(), ".", expectedAssetsDir, -1, -1), "Teardown: Saving expected policies failed.")
+	require.NoError(t, got.SaveAssetsTo(context.Background(), ".", gotAssetsDir, -1, -1), "Teardown: Saving got policies failed.")
 
 	testutils.CompareTreesWithFiltering(t, gotAssetsDir, expectedAssetsDir, false)
 }

--- a/internal/policies/policies.go
+++ b/internal/policies/policies.go
@@ -212,7 +212,8 @@ func (r *readerAtToReader) Read(p []byte) (n int, err error) {
 // Directories will recursively project its content.
 // If there is no asset attached and relSrc is not "." then it returns an error.
 // The destination directory or file should not exists.
-func (pols *Policies) SaveAssetsTo(ctx context.Context, relSrc, dest string) (err error) {
+// If uid and gid are not 0, every directories and files will be chown to that user and group.
+func (pols *Policies) SaveAssetsTo(ctx context.Context, relSrc, dest string, uid, gid int) (err error) {
 	defer decorate.OnError(&err, i18n.G("can't save assets to %s"), dest)
 
 	log.Debugf(ctx, "export assets %q to %q", relSrc, dest)
@@ -227,10 +228,10 @@ func (pols *Policies) SaveAssetsTo(ctx context.Context, relSrc, dest string) (er
 	}
 
 	baseDir := strings.TrimSuffix(relSrc, "/")
-	return pols.saveAssetsRecursively(relSrc, dest, baseDir)
+	return pols.saveAssetsRecursively(relSrc, dest, baseDir, uid, gid)
 }
 
-func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string) (err error) {
+func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string, uid, gid int) (err error) {
 	// zip doesn’t like final /, even when listing them return it.
 	relSrc = strings.TrimSuffix(relSrc, "/")
 
@@ -253,6 +254,11 @@ func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string) (err e
 		if err := os.MkdirAll(dstPath, 0700); err != nil {
 			return err
 		}
+		if shouldChown(uid, gid) {
+			if err := os.Chown(dstPath, uid, gid); err != nil {
+				return err
+			}
+		}
 
 		// Remove any "." to match directory content
 		relSrc = strings.TrimLeft(relSrc, "./")
@@ -266,7 +272,7 @@ func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string) (err e
 			if !strings.HasPrefix(zipF.Name, relSrc) || zipF.Name == relSrc {
 				continue
 			}
-			if err := pols.saveAssetsRecursively(zipF.Name, dest, baseDir); err != nil {
+			if err := pols.saveAssetsRecursively(zipF.Name, dest, baseDir, uid, gid); err != nil {
 				return err
 			}
 		}
@@ -282,6 +288,11 @@ func (pols *Policies) saveAssetsRecursively(relSrc, dest, baseDir string) (err e
 
 	if _, err = io.Copy(outF, f); err != nil {
 		return err
+	}
+	if shouldChown(uid, gid) {
+		if err := outF.Chown(uid, gid); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -415,4 +426,16 @@ func (pols Policies) GetUniqueRules() map[string][]entry.Entry {
 	}
 
 	return r
+}
+
+// shouldChown notifies if we should skip chown for root or in tests.
+func shouldChown(uid, gid int) bool {
+	if uid == 0 && gid == 0 {
+		return false
+	}
+
+	if os.Getenv("ADSYS_SKIP_ROOT_CALLS") != "" {
+		return false
+	}
+	return true
 }

--- a/internal/policies/policies_test.go
+++ b/internal/policies/policies_test.go
@@ -312,8 +312,8 @@ func TestSaveAssetsTo(t *testing.T) {
 
 	tests := map[string]struct {
 		relSrc string
-		uid    int
-		gid    int
+		uid    int // we will default it to -1 if no set
+		gid    int // we will default it to -1 if no set
 
 		cacheSrc     string
 		readOnlyDest string
@@ -405,6 +405,13 @@ func TestSaveAssetsTo(t *testing.T) {
 			} else if !tc.destExists {
 				// we simulate unexisting dest by removing it
 				require.NoError(t, os.RemoveAll(dest), "Setup: can't mock unexisting dest")
+			}
+
+			if tc.uid == 0 {
+				tc.uid = -1
+			}
+			if tc.gid == 0 {
+				tc.gid = -1
 			}
 
 			pols, err := policies.NewFromCache(context.Background(), src)
@@ -900,7 +907,7 @@ func equalPoliciesToGolden(t *testing.T, got policies.Policies, golden string, u
 	err := got.Save(compareDir)
 	require.NoError(t, err, "Teardown: saving gpo should work")
 	if got.HasAssets() {
-		err = got.SaveAssetsTo(context.Background(), ".", filepath.Join(compareDir, "assets.db.uncompressed"), 0, 0)
+		err = got.SaveAssetsTo(context.Background(), ".", filepath.Join(compareDir, "assets.db.uncompressed"), -1, -1)
 		require.NoError(t, err, "Teardown: deserializing assets should work")
 		// Remove database that are different from machine to machine.
 		err = os.RemoveAll(filepath.Join(compareDir, "assets.db"))

--- a/internal/policies/scripts/scripts_test.go
+++ b/internal/policies/scripts/scripts_test.go
@@ -87,7 +87,7 @@ func TestApplyPolicy(t *testing.T) {
 		"no entries is an empty folder":      {},
 		"empty entries are discared":         {entries: []entry.Entry{{Key: "s", Value: "script3.sh\n\nscript1.sh"}}},
 
-		// computer cases -> no setuid/setgid
+		// computer cases -> no setuid/setgid (should be -1)
 		"computer, no systemctl with other directory than startup":       {computer: true, systemctlShouldFail: true, entries: defaultSingleScript},
 		"startup script for computer runs systemctl (systemctl success)": {computer: true, systemctlShouldFail: false, entries: []entry.Entry{{Key: "startup", Value: "script1.sh"}}},
 

--- a/internal/policies/scripts/scripts_test.go
+++ b/internal/policies/scripts/scripts_test.go
@@ -75,7 +75,7 @@ func TestApplyPolicy(t *testing.T) {
 
 		wantErr bool
 	}{
-		// user cases
+		// user cases -> setuid/setgid to current user in tests
 		"one script": {entries: defaultSingleScript},
 		"one directory, multiple scripts in order": {entries: []entry.Entry{{Key: "s", Value: "script3.sh\nscript1.sh\nscript2.sh"}}},
 		"multiple directories:": {entries: []entry.Entry{
@@ -87,7 +87,7 @@ func TestApplyPolicy(t *testing.T) {
 		"no entries is an empty folder":      {},
 		"empty entries are discared":         {entries: []entry.Entry{{Key: "s", Value: "script3.sh\n\nscript1.sh"}}},
 
-		// computer cases
+		// computer cases -> no setuid/setgid
 		"computer, no systemctl with other directory than startup":       {computer: true, systemctlShouldFail: true, entries: defaultSingleScript},
 		"startup script for computer runs systemctl (systemctl success)": {computer: true, systemctlShouldFail: false, entries: []entry.Entry{{Key: "startup", Value: "script1.sh"}}},
 
@@ -314,7 +314,7 @@ type sat struct {
 }
 
 // mockSaveAssetsTo returns a static mock directory with scripts.
-func (s sat) mockSaveAssetsTo(ctx context.Context, relSrc, dest string) (err error) {
+func (s sat) mockSaveAssetsTo(ctx context.Context, relSrc, dest string, uid int, gid int) (err error) {
 	if s.err {
 		return errors.New("mockSaveAssetsTo error")
 	}

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/GPT.INI
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/GPT.INI
@@ -1,0 +1,3 @@
+[General]
+Version=100
+displayName=GPT.INI for assets

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/asset1.img
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/asset1.img
@@ -1,0 +1,1 @@
+some data

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/asset2.img
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/asset2.img
@@ -1,0 +1,1 @@
+some asset 2 data

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/subdir/asset-in-subdir
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/random/subdir/asset-in-subdir
@@ -1,0 +1,1 @@
+some other data

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-no-extension
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-no-extension
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+script=$(realpath $0)
+# Our scripts are in: user/foo/scripts/<scripts>.
+# We want to write our execution order file in user/foo/.
+path=$(dirname $(dirname $(dirname ${script})))
+
+echo $(basename $0) >> "${path}/golden"

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-other.sh
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-other.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+script=$(realpath $0)
+# Our scripts are in: user/foo/scripts/<scripts>.
+# We want to write our execution order file in user/foo/.
+path=$(dirname $(dirname $(dirname ${script})))
+
+echo $(basename $0) >> "${path}/golden"

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-simple.sh
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/script-simple.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+script=$(realpath $0)
+# Our scripts are in: user/foo/scripts/<scripts>.
+# We want to write our execution order file in user/foo/.
+path=$(dirname $(dirname $(dirname ${script})))
+
+echo $(basename $0) >> "${path}/golden"

--- a/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/subdir/script-in-subdir.sh
+++ b/internal/policies/testdata/golden/saveassetsto/chown directories and files when requested/scripts/subdir/script-in-subdir.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+script=$(realpath $0)
+# Our scripts are in: user/foo/scripts/<scripts>.
+# We want to write our execution order file in user/foo/.
+path=$(dirname $(dirname $(dirname ${script})))
+
+echo $(basename $0) >> "${path}/golden"


### PR DESCRIPTION
Fix potential security race with user/gid reset

Only chown to uid and gid when creating directories and any fd before closing we are in control of.
This impacted the API for passing desired uid and gid.
Remove the final recursive reset.
Rework chowning when needed. Set -1 to be API compliant for no change.