### PR TITLE
internal/testutils: invoke smbd with option accepted by 4.15+

### DIFF
--- a/internal/testutils/samba.go
+++ b/internal/testutils/samba.go
@@ -18,7 +18,7 @@ func SetupSmb(port int, sysvolDir string) func() {
 	dir, cleanup := mkSmbDirWithConf(smbPort, sysvolDir)
 
 	// #nosec:G204 - we control the directory we run smbd on (on tests)
-	cmd := exec.Command("smbd", "-FS", "-s", filepath.Join(dir, "smbd.conf"))
+	cmd := exec.Command("smbd", "-F", "--debug-stdout", "-s", filepath.Join(dir, "smbd.conf"))
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		log.Fatalf("Setup: can’t get smb output: %v", err)

--- a/internal/testutils/samba.go
+++ b/internal/testutils/samba.go
@@ -33,7 +33,7 @@ func SetupSmb(port int, sysvolDir string) func() {
 	if err != nil {
 		log.Fatalf("Setup: couldn't understand smbd version %q: %v", verString, err)
 	}
-	if (major > 4 || minor >= 15) {
+	if major > 4 || minor >= 15 {
 		cmd = exec.Command("smbd", "-F", "--debug-stdout", "-s", filepath.Join(dir, "smbd.conf"))
 	} else {
 		cmd = exec.Command("smbd", "-SF", "-s", filepath.Join(dir, "smbd.conf"))

--- a/internal/testutils/samba.go
+++ b/internal/testutils/samba.go
@@ -29,7 +29,7 @@ func SetupSmb(port int, sysvolDir string) func() {
 	}
 
 	var major, minor int
-	_, err = fmt.Sscanf(string(verString), "Version %i.%i", &major, &minor)
+	_, err = fmt.Sscanf(string(verString), "Version %d.%d", &major, &minor)
 	if err != nil {
 		log.Fatalf("Setup: couldn't understand smbd version %q: %v", verString, err)
 	}


### PR DESCRIPTION
Because obviously an "Improved command line user experience" (from the
Samba 4.15.0 release notes) means incompatible changes, adsys currently
ftbfs becaus smbd no longer takes -S / --log-stdout as an option, it's
now --debug-stdout.