### PR TITLE
Try reducing race conditions when testing configuration change

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -219,6 +220,9 @@ func TestInit(t *testing.T) {
 				Value string
 			}{}
 
+			// Let’s force a sync to make sure the initial files are written on disk
+			syscall.Sync()
+
 			var callbackCalled int
 			firstCallbackDone, secondCallbackDone := make(chan struct{}), make(chan struct{})
 			err = config.Init(prefix, cmd, vip, func(refreshed bool) error {
@@ -255,6 +259,8 @@ func TestInit(t *testing.T) {
 			if tc.changeConfigWith != "" {
 				err = os.WriteFile(filepath.Join(configDir, prefix+".yaml"), []byte(tc.changeConfigWith), 0600)
 				require.NoError(t, err, "Setup: failed to write initial config file")
+				// Let’s force a sync to make sure the file is written on disk
+				syscall.Sync()
 				select {
 				case <-secondCallbackDone:
 					if tc.wantCallbackCalled != 2 {


### PR DESCRIPTION
Ensure the files are committed on disk for the refresh to be taken into
account.
This is in hope that on VM tests, we get less time-sensitive failures.