### PR TITLE
Workaround tests hanging on ppcel64

### DIFF
--- a/internal/testutils/samba.go
+++ b/internal/testutils/samba.go
@@ -54,6 +54,10 @@ func SetupSmb(port int, sysvolDir string) func() {
 			log.Fatalf("Setup: failed to kill smbd process: %v", err)
 		}
 
+		if err := stderr.Close(); err != nil {
+			log.Fatalf("Setup: failed to close stderr on smbd process: %v", err)
+		}
+
 		d, err := io.ReadAll(stderr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Setup: Can't show stderr from smbd command: %v", err)


### PR DESCRIPTION
When killing smbd process, on ppcel64, stderr was not closed, causing
the tests to hang forever.