### PR TITLE
Switch Title generation to non deprecated function

### DIFF
--- a/internal/ad/admxgen/admxgen.go
+++ b/internal/ad/admxgen/admxgen.go
@@ -53,6 +53,8 @@ import (
 	"github.com/ubuntu/adsys/internal/decorate"
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // expandedCategories generation
@@ -414,9 +416,9 @@ func (g generator) toID(key string, s ...string) string {
 	r := g.distroID
 
 	for _, e := range s {
-		r += re.ReplaceAllString(strings.Title(e), "")
+		r += re.ReplaceAllString(cases.Title(language.Und, cases.NoLower).String(e), "")
 	}
-	return r + re.ReplaceAllString(strings.Title(key), "")
+	return r + re.ReplaceAllString(cases.Title(language.Und, cases.NoLower).String(key), "")
 }
 
 func (g generator) expandedCategoriesToADMX(expandedCategories []expandedCategory, dest string) (err error) {

--- a/internal/ad/admxgen/common/common.go
+++ b/internal/ad/admxgen/common/common.go
@@ -3,9 +3,10 @@ package common
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/ubuntu/adsys/internal/i18n"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -73,7 +74,7 @@ func (p ExpandedPolicy) GetDefaultForADM() string {
 
 // ValidClass returns a valid, capitalized class. It will error out if it can’t match the input as valid class.
 func ValidClass(class string) (string, error) {
-	c := strings.Title(class)
+	c := cases.Title(language.Und, cases.NoLower).String(class)
 
 	if c != "" && c != "User" && c != "Machine" {
 		return "", fmt.Errorf(i18n.G("invalid class %q"), class)


### PR DESCRIPTION
strings.Title() is deprecated in Go 1.18, switch to golang.org/x/text ini
adm* code generation.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>
Co-authored-by: Gabriel Nagy <gabriel.nagy@canonical.com>