### PR TITLE
Ensure we can execute machine and user scripts

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,7 @@
 ./debian/99-adsys-privilege-enforcement.conf etc/polkit-1/localauthority.conf.d/
 ./debian/99-adsys-privilege-enforcement etc/sudoers.d/
 pam/pam-configs usr/share
+systemd/*.mount lib/systemd/system/
 systemd/*.service lib/systemd/system/
 systemd/*.socket lib/systemd/system/
 systemd/*.timer lib/systemd/system/

--- a/systemd/run-adsys.mount
+++ b/systemd/run-adsys.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Allow /run/adsys to execute binaries: machine and user scripts are downloaded there
+Before=adsys-boot.service
+
+[Mount]
+What=tmpfs
+Where=/run/adsys
+Type=tmpfs
+Options=nosuid,nodev,mode=0755
+ReadWriteOnly=true
+LazyUnmount=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
/run is now noexec on Ubuntu. Ensure that we can execute the scripts in
/run/adsys subdirectories. The scripts mecanism has been reviewed by the
security team, so we can reset them as executable.

Co-authored-by: Jean-Baptiste Lallement <jean-baptiste@ubuntu.com>