### PR TITLE
Align setting verbosity between admxgen and adsys*

### DIFF
--- a/cmd/adsysd/client/client.go
+++ b/cmd/adsysd/client/client.go
@@ -46,7 +46,7 @@ func New() *App {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// command parsing has been successful. Returns runtime (or configuration) error now and so, don’t print usage.
 			a.rootCmd.SilenceUsage = true
-			return config.Init("adsys", a.rootCmd, a.viper, func(refreshed bool) error {
+			err := config.Init("adsys", a.rootCmd, a.viper, func(refreshed bool) error {
 				var newConfig daemonConfig
 				if err := config.LoadConfig(&newConfig, a.viper); err != nil {
 					return err
@@ -74,6 +74,9 @@ func New() *App {
 				// Timeout reload is ignored
 				return nil
 			})
+			// Set configured verbose status for the daemon.
+			config.SetVerboseMode(a.config.Verbose)
+			return err
 		},
 		Args: cmdhandler.SubcommandsRequiredWithSuggestions,
 		RunE: cmdhandler.NoCmd,

--- a/cmd/adsysd/daemon/daemon.go
+++ b/cmd/adsysd/daemon/daemon.go
@@ -60,7 +60,7 @@ func New() *App {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// command parsing has been successful. Returns runtime (or configuration) error now and so, don’t print usage.
 			a.rootCmd.SilenceUsage = true
-			return config.Init("adsys", a.rootCmd, a.viper, func(refreshed bool) error {
+			err := config.Init("adsys", a.rootCmd, a.viper, func(refreshed bool) error {
 				var newConfig daemonConfig
 				if err := config.LoadConfig(&newConfig, a.viper); err != nil {
 					return err
@@ -97,11 +97,12 @@ func New() *App {
 				}
 				return nil
 			})
+			// Set configured verbose status for the daemon.
+			config.SetVerboseMode(a.config.Verbose)
+			return err
 		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config.SetVerboseMode(a.config.Verbose)
-
 			adsys, err := adsysservice.New(context.Background(), a.config.ADServer, a.config.ADDomain,
 				adsysservice.WithCacheDir(a.config.CacheDir),
 				adsysservice.WithRunDir(a.config.RunDir),


### PR DESCRIPTION
We always set the verbosity the same way between the two binaries. This
ensure consistency.