### PR TITLE
Allow config.Init to work on non-persistent flags

### DIFF
--- a/cmd/adsysd/client/client.go
+++ b/cmd/adsysd/client/client.go
@@ -86,7 +86,7 @@ func New() *App {
 	a.viper = viper.New()
 
 	cmdhandler.InstallVerboseFlag(&a.rootCmd, a.viper)
-	cmdhandler.InstallConfigFlag(&a.rootCmd)
+	cmdhandler.InstallConfigFlag(&a.rootCmd, true)
 	cmdhandler.InstallSocketFlag(&a.rootCmd, a.viper, consts.DefaultSocket)
 
 	a.rootCmd.PersistentFlags().IntP("timeout", "t", consts.DefaultClientTimeout, i18n.G("time in seconds before cancelling the client request when the server gives no result. 0 for no timeout."))

--- a/cmd/adsysd/daemon/daemon.go
+++ b/cmd/adsysd/daemon/daemon.go
@@ -135,7 +135,7 @@ func New() *App {
 	a.viper = viper.New()
 
 	cmdhandler.InstallVerboseFlag(&a.rootCmd, a.viper)
-	cmdhandler.InstallConfigFlag(&a.rootCmd)
+	cmdhandler.InstallConfigFlag(&a.rootCmd, true)
 	cmdhandler.InstallSocketFlag(&a.rootCmd, a.viper, consts.DefaultSocket)
 
 	a.rootCmd.PersistentFlags().StringP("cache-dir", "", consts.DefaultCacheDir, i18n.G("directory where ADsys caches GPOs downloads and policies."))

--- a/internal/cmdhandler/cmdhandler.go
+++ b/internal/cmdhandler/cmdhandler.go
@@ -56,6 +56,10 @@ func InstallSocketFlag(cmd *cobra.Command, viper *viper.Viper, defaultPath strin
 }
 
 // InstallConfigFlag adds the -c and --config option to select a configuration file and returns the reference to it.
-func InstallConfigFlag(cmd *cobra.Command) *string {
-	return cmd.PersistentFlags().StringP("config", "c", "", i18n.G("use a specific configuration file"))
+func InstallConfigFlag(cmd *cobra.Command, persistent bool) *string {
+	target := cmd.Flags()
+	if persistent {
+		target = cmd.PersistentFlags()
+	}
+	return target.StringP("config", "c", "", i18n.G("use a specific configuration file"))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,18 +38,21 @@ func SetVerboseMode(level int) {
 // It calls immediately the configChanged function with refreshed set to false (as this is the first call)
 // to let you deserialize the initial configuration and returns any errors.
 // Then, it automatically watches any configuration changes and will call configChanged with refresh set to true.
-func Init(name string, rootCmd cobra.Command, vip *viper.Viper, configChanged func(refreshed bool) error) (err error) {
+func Init(name string, cmd cobra.Command, vip *viper.Viper, configChanged func(refreshed bool) error) (err error) {
 	defer decorate.OnError(&err, i18n.G("can't load configuration"))
 
+	// Force a visit of the local flags so persistent flags for all parents are merged.
+	cmd.LocalFlags()
+
 	// Get cmdline flag for verbosity to configure logger until we have everything parsed.
-	v, err := rootCmd.PersistentFlags().GetCount("verbose")
+	v, err := cmd.Flags().GetCount("verbose")
 	if err != nil {
-		return fmt.Errorf("internal error: no persistent verbose flag installed on rootCmd: %w", err)
+		return fmt.Errorf("internal error: no persistent verbose flag installed on cmd: %w", err)
 	}
 
 	SetVerboseMode(v)
 
-	if v, err := rootCmd.PersistentFlags().GetString("config"); err == nil && v != "" {
+	if v, err := cmd.Flags().GetString("config"); err == nil && v != "" {
 		vip.SetConfigFile(v)
 	} else {
 		vip.SetConfigName(name)


### PR DESCRIPTION
Previously we made the assumption that the command passed to config.Init is always the root command. This works well when the config flag is persistent and defined on the root command.

Update the config initialization API to also work with cases where we don't want to define a persistent root flag and only have the `--config` flag on subcommands.

It is the responsibility of the caller to ensure that the correct Cobra command is passed to config.Init.