### PR TITLE
Only cross-build windows binary on amd64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: ${source:Synopsis}
  ${source:Extended-Description}
 
 Package: adsys-windows
-Architecture: any
+Architecture: amd64
 Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},


### PR DESCRIPTION
Others arches are not supported.