### PR TITLE
Update packaging to work across architectures

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: ${source:Synopsis}
  ${source:Extended-Description}
 
 Package: adsys-windows
-Architecture: any
+Architecture: amd64 arm64
 Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},

--- a/debian/rules
+++ b/debian/rules
@@ -2,15 +2,28 @@
 #export DH_VERBOSE = 1
 
 export GOCACHE=$(shell mktemp -d /tmp/gocache-XXXX)
-export GOFLAGS=-ldflags=-X=github.com/ubuntu/adsys/internal/consts.Version=$(shell dpkg-parsechangelog -S Version) --mod=vendor -buildmode=pie
+
+WIN_ARCHS := amd64 arm64
+WIN_GOFLAGS := -ldflags=-X=github.com/ubuntu/adsys/internal/consts.Version=$(shell dpkg-parsechangelog -S Version) --mod=vendor
+export GOFLAGS := $(WIN_GOFLAGS) -buildmode=pie
+
+# PIE on Windows is only supported for amd64
+ifeq ($(shell dpkg --print-architecture),amd64)
+	WIN_GOFLAGS += -buildmode=pie
+endif
+
+# Only build adwatchd on supported architectures
+ifneq ($(filter $(shell dpkg --print-architecture),$(WIN_ARCHS)),)
+	WINDOWS_BUILD := 1
+endif
 
 # Copy in build directory all content to embed
 export DH_GOLANG_INSTALL_ALL := 1
 
-# Skip integration tests when building package: they need docker images.
+# Skip integration tests when building package: they need docker images
 export ADSYS_SKIP_INTEGRATION_TESTS=1
 
-# Skip tests that require sudo: they will run as part of autopkgtests.
+# Skip tests that require sudo: they will run as part of autopkgtests
 export ADSYS_SKIP_SUDO_TESTS=1
 
 %:
@@ -18,15 +31,17 @@ export ADSYS_SKIP_SUDO_TESTS=1
 
 override_dh_auto_clean:
 	dh_auto_clean
-	# create the vendor directory when building the source package
+	# Create the vendor directory when building the source package
 	[ -d vendor/ ] || go mod vendor
 
 override_dh_auto_build:
-	# Build on linux only adsysd itself, and not generator or Windows binaries.
+	# Build on linux only adsysd itself, and not generator or Windows binaries
 	DH_GOLANG_BUILDPKG=github.com/ubuntu/adsys/cmd/adsysd dh_auto_build
 
-	# build the Windows executables for adwatchd
-	GOOS=windows DH_GOLANG_BUILDPKG=github.com/ubuntu/adsys/cmd/adwatchd dh_auto_build
+# Build the Windows executables for adwatchd where applicable
+ifeq ($(WINDOWS_BUILD),1)
+	GOFLAGS="$(WIN_GOFLAGS)" GOOS=windows DH_GOLANG_BUILDPKG=github.com/ubuntu/adsys/cmd/adwatchd dh_auto_build
+endif
 
 override_dh_auto_install:
 	dh_auto_install -- --no-source
@@ -43,17 +58,19 @@ override_dh_auto_install:
 	cp -a systemd/*.timer debian/tmp/lib/systemd/system/
 	cp -a systemd/user/*.service debian/tmp/usr/lib/systemd/user/
 
-	# separate windows binaries
+# Separate windows binaries
+ifeq ($(WINDOWS_BUILD),1)
 	mkdir -p debian/tmp/usr/share/adsys/windows
 	mv debian/tmp/usr/bin/windows_*/* debian/tmp/usr/share/adsys/windows
 	rmdir debian/tmp/usr/bin/windows_*
 
-	# ship admx/adml for ubuntu
+	# Ship admx/adml for ubuntu
 	cp -a policies/Ubuntu debian/tmp/usr/share/adsys/windows/policies
+endif
 
-	# install in /sbin
+	# Install in /sbin
 	mv debian/tmp/usr/bin/ debian/tmp/sbin
-	# create adsysctl command
+	# Create adsysctl command
 	ln -s adsysd debian/tmp/sbin/adsysctl
-	# run go generate to install assets, but don’t regenerate them
+	# Run go generate to install assets, but don’t regenerate them
 	GENERATE_ONLY_INSTALL_TO_DESTDIR=$(CURDIR)/debian/tmp go generate -tags tools $(GOFLAGS) ./...

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -5,5 +5,5 @@ Depends: @builddeps@
 
 # Run only tests that require root
 Test-Command: ./debian/tests/test sudo
-Restrictions: allow-stderr, needs-root
+Restrictions: allow-stderr, needs-root, skippable
 Depends: @builddeps@

--- a/debian/tests/test
+++ b/debian/tests/test
@@ -17,6 +17,12 @@ case $1 in
         PACKAGES_TO_TEST=./...
         ;;
     sudo)
+        arch=$(dpkg --print-architecture)
+        if [ "$arch" != "amd64" ] && [ "$arch" != "arm64" ]; then
+            echo "Skipping root tests for non-amd64/arm64 architecture"
+            exit 77
+        fi
+
         echo "Running root tests..."
         DIR_NAME=$(dirname "$0")
         PACKAGES_TO_TEST=$(cat "$DIR_NAME"/.sudo-packages)

--- a/internal/generators/copy.go
+++ b/internal/generators/copy.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/ubuntu/adsys/internal/generators"
 )
@@ -21,6 +22,7 @@ func main() {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		log.Fatalf("Couldn't create dest directory: %v", err)
 	}
+	defer syscall.Sync()
 
 	from, err := os.Open(os.Args[1])
 	if err != nil {


### PR DESCRIPTION
Opening this for early discussion as we still have to fix the failing `armhf` [build](https://launchpadlibrarian.net/610641368/buildlog_ubuntu-kinetic-armhf.adsys_0.8.6ubuntu12_BUILDING.txt.gz):
```
# github.com/ubuntu/adsys/vendor/github.com/mvo5/libsmbclient-go
In file included from src/github.com/ubuntu/adsys/vendor/github.com/mvo5/libsmbclient-go/libsmbclient.go:17:
/usr/include/samba-4.0/libsmbclient.h:84:13: error: size of array 'smbc_off_t_should_be_at_least_64bits_use_LFS_CFLAGS' is too large
   84 | typedef int smbc_off_t_should_be_at_least_64bits_use_LFS_CFLAGS[sizeof(off_t)-7];
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
------------------------------------
## Update packaging to work across architectures
- build/ship adwatchd on amd64 and arm64, other architectures are not supported by go
- build adwatchd with PIE on amd64 as other architectures are not supported
- run sudo autopkgtests on supported architectures (amd64 and arm64), skip them otherwise
- unify the rules comment format to be uppercase with no period at the end

## Force a sync when running generators
There's an edge case on the LP builders where due to some race condition we can get an error like the following after running the `go generate` command:

    cp: error reading 'debian/tmp/usr/share/polkit-1': Is a directory

It usually happens with different directories from the install file. From local/LP testing it looks like forcing a sync makes the issue disappear.