### PR TITLE
Increase copy generator sleep to 1 second

### DIFF
--- a/internal/generators/copy.go
+++ b/internal/generators/copy.go
@@ -27,8 +27,8 @@ func main() {
 		// Sleep and force a sync before exiting to avoid possible race
 		// conditions during the package build, where the paths to install are
 		// not fully written by the time dh_install runs.
-		time.Sleep(100 * time.Millisecond)
 		syscall.Sync()
+		time.Sleep(1 * time.Second)
 	}()
 
 	from, err := os.Open(os.Args[1])


### PR DESCRIPTION
We still got a failure on ppc64el (that went away on rebuild).

As we don't run this generator outside of packaging and CI it should be fairly non-intrusive to increase the sleep time to a second. Also it might be better for the sync to happen prior to the sleep.

We'll monitor this and see how it goes before spending more time on the issue.