### PR TITLE
Bump runner version for the Jira sync workflow

### DIFF
--- a/.github/workflows/sync-gh-jira.yaml
+++ b/.github/workflows/sync-gh-jira.yaml
@@ -3,7 +3,7 @@ on: [issues, issue_comment]
 jobs:
   sync-issues:
     name: Sync issues to Jira
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: ubuntu/sync-issues-github-jira@v1
       with:


### PR DESCRIPTION
The ubuntu/sync-issues-github-jira action can now convert GitHub Markdown to JIRA Markdown. However, this is only supported starting with Ubuntu 22.04 which is not yet `ubuntu-latest`.

Explicitly request `ubuntu-22.04`. We can revert this change when GitHub changes `ubuntu-latest` to point at `ubuntu-22.04`.