### PR TITLE
Clean up GitHub Actions workflows

### DIFF
--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build admxgen static binary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -24,7 +24,7 @@ jobs:
           mkdir /tmp/adsys
           CO_ENABLED=0 go build ./cmd/admxgen/
       - name: Upload admxgen
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: admxgen
           path: |
@@ -91,7 +91,7 @@ jobs:
       image: ${{ matrix.releases }}
     steps:
       - name: Download admxgen and definition files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: admxgen
       - name: Install desktop with all default package in container
@@ -112,7 +112,7 @@ jobs:
           artifacts_name=${artifacts_name/:/-}
           echo "artifacts_name=${artifacts_name}" >> $GITHUB_ENV
       - name: Generated definition files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: policies-${{ env.artifacts_name }}
           path: out/*
@@ -131,7 +131,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt update
           sudo DEBIAN_FRONTEND=noninteractive apt install -y distro-info
       - name: Download all available artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: Display structure of downloaded files
@@ -158,7 +158,7 @@ jobs:
           artifacts/admxgen/admxgen admx --auto-detect-releases ${allowflag} artifacts/admxgen/cmd/admxgen/defs/categories.yaml wanted/ .
           ls -R
       - name: Upload adm template files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: adm-${{ matrix.releases }}
           path: Ubuntu.adm*
@@ -169,12 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-ad
     steps:
-      - name: Install dependencies, including git for checkout
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y git
-      # Checkout code with git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download adm template files for "all"
         uses: actions/download-artifact@v2
         with:
@@ -193,7 +188,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: Refresh policy definition files
           title: Refresh policy definition files

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -11,17 +11,13 @@ jobs:
   update-po:
     name: Update po files
     runs-on: ubuntu-latest
-    container: ubuntu:rolling
     steps:
-      - name: Install dependencies, including git for checkout
+      - name: Install dependencies
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y gettext git
-      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
-        run: git config --global --add safe.directory /__w/adsys/adsys
+          sudo DEBIAN_FRONTEND=noninteractive apt update
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y gettext
       # Checkout code with git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
       # Install go
@@ -45,7 +41,7 @@ jobs:
           echo "modified=${hasModif}" >> $GITHUB_ENV
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: Auto update po files
           title: Auto update po files
@@ -63,17 +59,13 @@ jobs:
     # This should just be "after", but we don't want the 2 jobs to push at the same time
     needs: update-po
     runs-on: ubuntu-latest
-    container: ubuntu:rolling
     steps:
-      - name: Install dependencies, including git for checkout
+      - name: Install dependencies
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y libsmbclient-dev gcc pkg-config git
-      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
-        run: git config --global --add safe.directory /__w/adsys/adsys
+          sudo DEBIAN_FRONTEND=noninteractive apt update
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y libsmbclient-dev gcc pkg-config
       # Checkout code with git
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
       # Install go

--- a/.github/workflows/documentation-update.yaml
+++ b/.github/workflows/documentation-update.yaml
@@ -15,11 +15,11 @@ jobs:
     if: github.event_name == 'gollum'
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: repo
       - name: Checkout wiki
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: wiki
           repository: ubuntu/adsys.wiki
@@ -45,11 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: repo
       - name: Checkout wiki
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: wiki
           repository: ubuntu/adsys.wiki

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
     steps:
-      # We install git before checkouting so that actions/checkout use the git command and persists .git/ thus
       - name: Install dependencies
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y ca-certificates git gcc pkg-config libsmbclient-dev
+          DEBIAN_FRONTEND=noninteractive apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc pkg-config libsmbclient-dev
       - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
         run: git config --global --add safe.directory /__w/adsys/adsys
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Code formatting, vet, static checker Security…
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           args: "--config .golangci-ci.yaml"
       - name: Module files are up to date
@@ -46,7 +48,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -54,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates gcc gettext libsmbclient-dev samba sudo dconf-cli python3-coverage libnss-wrapper
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates gcc gettext libsmbclient-dev samba sudo dconf-cli python3-coverage libnss-wrapper curl
       - name: Set required environment variables
         run: echo "SUDO_PACKAGES=$(cat debian/tests/.sudo-packages)" >> $GITHUB_ENV
       - name: Authenticate to docker local registry and pull image with our token
@@ -81,12 +83,8 @@ jobs:
           ADSYS_SKIP_SUDO_TESTS=1 go test -race ./...
           # Use command substitution to preserve go binary path (sudo does not preserve path even with -E)
           sudo -E $(which go) test -race ${{ env.sudo_packages }}
-      - name: Install curl for codecov
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y curl
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: /tmp/coverage.combined.out
 
@@ -96,7 +94,7 @@ jobs:
     env:
       packages: ./internal/loghooks ./internal/watchdservice ./internal/watchdtui ./internal/watcher ./internal/config/watchd ./cmd/adwatchd/integration_tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v3
@@ -149,12 +147,11 @@ jobs:
       # Add dependencies
       - name: Install dependencies
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y ca-certificates gcc pkg-config protobuf-compiler gettext git libsmbclient-dev
+          DEBIAN_FRONTEND=noninteractive apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y git ca-certificates gcc pkg-config protobuf-compiler gettext libsmbclient-dev
       - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
         run: git config --global --add safe.directory /__w/adsys/adsys
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod


### PR DESCRIPTION
- update used actions to latest
- remove git safe path workaround
- install curl in the same step as the other dependencies
- do not use containers unless explicitly needed