### PR TITLE
Rework skipping integration tests

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -eu
 
-          ADSYS_SKIP_SUDO_TESTS=1 go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=count ./...
+          go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=count ./...
 
           # Run integration tests that need sudo
           # Use command substitution to preserve go binary path (sudo does not preserve path even with -E)
@@ -85,7 +85,7 @@ jobs:
           grep -hv -e "mode: set" -e "testutils" -e "pb.go:" /tmp/coverage.out /tmp/coverage.sudo.out > /tmp/coverage.combined.out
       - name: Run tests (with race detector)
         run: |
-          ADSYS_SKIP_SUDO_TESTS=1 go test -race ./...
+          go test -race ./...
           # Use command substitution to preserve go binary path (sudo does not preserve path even with -E)
           sudo -E $(which go) test -race ${{ env.sudo_packages }}
       - name: Upload coverage to Codecov
@@ -123,7 +123,7 @@ jobs:
         run: go test ${{ env.packages }}
       - name: Run tests (with race detector)
         env:
-          ADWATCHD_SKIP_INTEGRATION_TESTS: 1
+          ADSYS_SKIP_INTEGRATION_TESTS: 1
         run: go test -race ${{ env.packages }}
         # There are some cryptic "The pipe has been closed" errors on Windows
         # that arise from running the tests with the race detector enabled. We

--- a/cmd/adwatchd/integration_tests/adwatchd_test.go
+++ b/cmd/adwatchd/integration_tests/adwatchd_test.go
@@ -15,7 +15,14 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("ADWATCHD_SKIP_INTEGRATION_TESTS") != "" || os.Getenv("ADSYS_SKIP_SUDO_TESTS") != "" {
+	// We use > 0 to allow Windows to pass through
+	if os.Geteuid() > 0 {
+		fmt.Println("Test has to be run as root, skipping...")
+		return
+	}
+
+	// This is used for skipping race tests in CI
+	if os.Getenv("ADSYS_SKIP_INTEGRATION_TESTS") != "" {
 		fmt.Println("Integration tests skipped as requested")
 		return
 	}

--- a/debian/rules
+++ b/debian/rules
@@ -21,10 +21,8 @@ endif
 export DH_GOLANG_INSTALL_ALL := 1
 
 # Skip integration tests when building package: they need docker images
+# Tests needing sudo will be skipped automatically
 export ADSYS_SKIP_INTEGRATION_TESTS=1
-
-# Skip tests that require sudo: they will run as part of autopkgtests
-export ADSYS_SKIP_SUDO_TESTS=1
 
 %:
 	dh $@ --buildsystem=golang --with=golang,apport

--- a/debian/tests/test
+++ b/debian/tests/test
@@ -13,7 +13,6 @@ case $1 in
     no-sudo)
         echo "Running non-root tests..."
         export ADSYS_SKIP_INTEGRATION_TESTS=1
-        export ADSYS_SKIP_SUDO_TESTS=1
         PACKAGES_TO_TEST=./...
         ;;
     sudo)

--- a/internal/testutils/tests.go
+++ b/internal/testutils/tests.go
@@ -1,0 +1,17 @@
+package testutils
+
+import (
+	"os"
+	"testing"
+)
+
+// SkipUnlessRoot skips the test if the current user is not root.
+// The function is a no-op on Windows.
+func SkipUnlessRoot(t *testing.T) {
+	t.Helper()
+
+	// We use > 0 to allow Windows to pass through
+	if os.Geteuid() > 0 {
+		t.Skip("Test has to be run as root, skipping...")
+	}
+}

--- a/internal/watchdtui/watchdtui_test.go
+++ b/internal/watchdtui/watchdtui_test.go
@@ -419,9 +419,11 @@ func TestInteractiveInput(t *testing.T) {
 }
 
 func TestInteractiveInstall(t *testing.T) {
-	if os.Getenv("ADWATCHD_SKIP_INTEGRATION_TESTS") != "" || os.Getenv("ADSYS_SKIP_SUDO_TESTS") != "" {
+	testutils.SkipUnlessRoot(t)
+
+	// This is used for skipping race tests in Windows CI
+	if os.Getenv("ADSYS_SKIP_INTEGRATION_TESTS") != "" {
 		t.Skip("Integration tests skipped as requested")
-		return
 	}
 
 	svc, err := watchdservice.New(context.Background())
@@ -465,9 +467,11 @@ func TestInteractiveInstall(t *testing.T) {
 }
 
 func TestInteractiveUpdate(t *testing.T) {
-	if os.Getenv("ADWATCHD_SKIP_INTEGRATION_TESTS") != "" || os.Getenv("ADSYS_SKIP_SUDO_TESTS") != "" {
+	testutils.SkipUnlessRoot(t)
+
+	// This is used for skipping race tests in CI
+	if os.Getenv("ADSYS_SKIP_INTEGRATION_TESTS") != "" {
 		t.Skip("Integration tests skipped as requested")
-		return
 	}
 
 	tests := map[string]struct {


### PR DESCRIPTION
With the addition of the Windows codebase we needed to skip certain tests on Linux if we did not have root permissions. An `ADSYS_SKIP_SUDO_TESTS` flag was added for this.

Additionally, some tests proved to be problematic when ran with `-race` on Windows. Thus, we added `ADWATCHD_SKIP_INTEGRATION_TESTS` to account for this.

Besides this, adsys already had `ADSYS_SKIP_INTEGRATION_TESTS` before which was used to skip integration tests during Debian packaging and autopkgtests.

This led to, among other things, tests failing if one ran go test ./... without root privileges on Linux. To simplify the situation:
- automatically skip tests requiring root and log an appropriate message
- drop ADSYS_SKIP_SUDO_TESTS as it's accounted by the change above
- rename ADWATCHD_SKIP_INTEGRATION_TESTS to ADSYS_SKIP_INTEGRATION_TESTS in order to have a single environment variable controlling this

Closes #469 / DEENG-509