### PR TITLE
Allow running mount_handler tests as part of go test

### DIFF
--- a/internal/policies/mount/adsys_mount/run_test.go
+++ b/internal/policies/mount/adsys_mount/run_test.go
@@ -1,0 +1,36 @@
+// Package adsysmount_test runs rust tests from a go test global command
+package adsysmount_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/ubuntu/adsys/internal/testutils"
+)
+
+func TestRust(t *testing.T) {
+	t.Parallel()
+
+	// properly inform Go about which files to use for cache by reading input files.
+	testutils.MarkRustFilesForTestCache(t)
+
+	cmd := exec.Command("cargo", "test")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fail()
+	}
+}
+
+func TestMain(m *testing.M) {
+	canRun, withCoverage := testutils.CanRunRustTests()
+	if !canRun {
+		os.Exit(1)
+	}
+
+	_ = withCoverage
+
+	m.Run()
+}

--- a/internal/testutils/files.go
+++ b/internal/testutils/files.go
@@ -291,6 +291,6 @@ func markForTestCache(t *testing.T, roots []string) {
 		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			return nil
 		})
-		require.NoError(t, err, "Setup: listing input files for caching handling")
+		require.NoError(t, err, "Setup: Error when listing input files for caching handling")
 	}
 }

--- a/internal/testutils/files.go
+++ b/internal/testutils/files.go
@@ -282,3 +282,15 @@ func ignoreDconfDB(src string, entries []os.FileInfo) []string {
 	}
 	return r
 }
+
+// markForTestCache list all root directories/files so that they are marked in the test cache.
+func markForTestCache(t *testing.T, roots []string) {
+	t.Helper()
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			return nil
+		})
+		require.NoError(t, err, "Setup: listing input files for caching handling")
+	}
+}

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -1,0 +1,30 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// MarkRustFilesForTestCache marks all rust files and related content to be in the Go test caching infra.
+func MarkRustFilesForTestCache(t *testing.T) {
+	t.Helper()
+
+	markForTestCache(t, []string{"src", "testdata", "Cargo.toml", "Cargo.lock"})
+}
+
+// CanRunRustTests returns if we can run rust tests via cargo on this machine.
+// It returns if code coverage is supported.
+func CanRunRustTests() (canRun, withCoverage bool) {
+	d, err := exec.Command("cargo", "--version").CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't run Rust tests, cargo can't be executed: %v\n", err)
+		return false, false
+	}
+
+	// TODO: detect nightly for code coverage
+	fmt.Println(string(d))
+
+	return true, false
+}


### PR DESCRIPTION
Hook up running rust tests from go test command, with proper detection and cache handling.