### PR TITLE
Refactor tracking and generating coverage files

### DIFF
--- a/cmd/adsysd/integration_tests/adsysctl_policy_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_policy_test.go
@@ -1079,15 +1079,16 @@ func setupSubprocessForTest(t *testing.T, currentUser string, otherUsers ...stri
 			}
 			hasExplicitTestAsRunArg = true
 		}
-		// Cover subprocess in a different file that we will merge when the test ends
 		if strings.HasPrefix(arg, "-test.coverprofile=") {
-			coverage := strings.TrimPrefix(arg, "-test.coverprofile=")
-			coverage = fmt.Sprintf("%s.%s", coverage, strings.ToLower(t.Name()))
-			arg = fmt.Sprintf("-test.coverprofile=%s", coverage)
-			testutils.AddCoverageFile(coverage)
+			continue
 		}
 		subArgs = append(subArgs, arg)
 	}
+	// Cover subprocess in a different file that we will merge when the test ends
+	if testCoverFile := testutils.TrackTestCoverage(t); testCoverFile != "" {
+		subArgs = append(subArgs, "-test.coverprofile="+testCoverFile)
+	}
+
 	if !hasExplicitTestAsRunArg {
 		subArgs = append(subArgs, fmt.Sprintf("-test.run=%s", t.Name()))
 	}

--- a/internal/ad/internal_test.go
+++ b/internal/ad/internal_test.go
@@ -573,7 +573,6 @@ func TestMain(m *testing.M) {
 	// Don’t setup samba or sssd for mock helpers
 	if strings.Contains(strings.Join(os.Args, " "), "TestMock") {
 		m.Run()
-		testutils.MergeCoverages()
 		return
 	}
 

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -24,10 +24,10 @@ var (
 )
 
 // TrackTestCoverage starts tracking coverage in a dedicated file based on current test name.
-// This filewill be merged to the current coverage main file.
+// This file will be merged to the current coverage main file.
 // It’s up to the test use the returned path to file golang-compatible cover format content.
 // To collect all coverages, then MergeCoverages() should be called after m.Run().
-// If coverage is not enable, nothing is done.
+// If coverage is not enabled, nothing is done.
 func TrackTestCoverage(t *testing.T) (testCoverFile string) {
 	t.Helper()
 
@@ -57,19 +57,19 @@ func TrackTestCoverage(t *testing.T) (testCoverFile string) {
 
 // MergeCoverages append all coverage files marked for merging to main Go Cover Profile.
 // This has to be called after m.Run() in TestMain so that the main go cover profile is created.
-// This has no action of profile is not enabled.
+// This has no action if profiling is not enabled.
 func MergeCoverages() {
 	coveragesToMergeMu.Lock()
 	defer coveragesToMergeMu.Unlock()
 	for _, cov := range coveragesToMerge {
 		if err := appendToFile(cov, goMainCoverProfile); err != nil {
-			log.Fatalf("Teardown: can’t inject coverage to golang one: %v", err)
+			log.Fatalf("Teardown: can’t inject coverage into the golang one: %v", err)
 		}
 	}
 	coveragesToMerge = nil
 }
 
-// WantCoverage returns if coverage was requested in test.
+// WantCoverage returns true if coverage was requested in test.
 func WantCoverage() bool {
 	for _, arg := range os.Args {
 		if !strings.HasPrefix(arg, "-test.coverprofile=") {

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -84,7 +84,7 @@ func WantCoverage() bool {
 func appendToFile(src, dst string) error {
 	f, err := os.Open(filepath.Clean(src))
 	if err != nil {
-		return fmt.Errorf("can't open coverage file named: %w", err)
+		return fmt.Errorf("can't open coverage file: %w", err)
 	}
 	defer func() {
 		if err := f.Close(); err != nil {


### PR DESCRIPTION
Encapsulate the tracking methods fully in testutils. The API is minimized and don’t rely on the consumer to pass the correct filename anymore, as it’s internal.
Adapt python coverage to this new API.
Simplify the collect and make it (if needed) able to recollect after first tracking.
Add many more comments on API documentation.