### PR TITLE
Rust tests with coverage and CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates git gcc pkg-config libsmbclient-dev
+          # Rust/cargo dependencies
+          DEBIAN_FRONTEND=noninteractive apt install -y curl libglib2.0-dev
       - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
         run: git config --global --add safe.directory /__w/adsys/adsys
       - uses: actions/checkout@v3
@@ -48,6 +50,17 @@ jobs:
       - name: Building
         run: go build ./...
         if: ${{ always() }}
+      - name: Install cargo (stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+        if: ${{ always() }}
+      - name: Building rust code
+        run: |
+          set -eu
+          # mount manager handler
+          cargo build --manifest-path ./internal/policies/mount/adsys_mount/Cargo.toml
+        if: ${{ always() }}
 
   tests:
     name: Tests
@@ -62,6 +75,8 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update
           sudo DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates gcc gettext libsmbclient-dev samba sudo dconf-cli python3-coverage libnss-wrapper curl
+          # Rust dependencies
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y libglib2.0-dev
       - name: Set required environment variables
         run: echo "SUDO_PACKAGES=$(cat debian/tests/.sudo-packages)" >> $GITHUB_ENV
       - name: Authenticate to docker local registry and pull image with our token
@@ -70,6 +85,13 @@ jobs:
 
           echo "${{ github.token }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
           docker pull docker.pkg.github.com/ubuntu/adsys/systemdaemons:0.1
+      - name: Install cargo (nightly to get coverage)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install grcov
+        run: cargo install grcov
       - name: Run tests
         run: |
           set -eu

--- a/internal/policies/mount/adsys_mount/run_test.go
+++ b/internal/policies/mount/adsys_mount/run_test.go
@@ -1,0 +1,36 @@
+// Package adsysmount_test runs rust tests from a go test global command
+package adsysmount_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/ubuntu/adsys/internal/testutils"
+)
+
+func TestRust(t *testing.T) {
+	t.Parallel()
+
+	// properly inform Go about which files to use for cache by reading input files.
+	testutils.MarkRustFilesForTestCache(t)
+
+	cmd := exec.Command("cargo", "test")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fail()
+	}
+}
+
+func TestMain(m *testing.M) {
+	canRun, withCoverage := testutils.CanRunRustTests()
+	if !canRun {
+		os.Exit(1)
+	}
+
+	_ = withCoverage
+
+	m.Run()
+}

--- a/internal/policies/mount/adsys_mount/src/coverage.go
+++ b/internal/policies/mount/adsys_mount/src/coverage.go
@@ -1,0 +1,2 @@
+// Package forcoverage file is only here so that it’s recognized as a go package when computing coverage
+package forcoverage

--- a/internal/testutils/files.go
+++ b/internal/testutils/files.go
@@ -291,6 +291,6 @@ func markForTestCache(t *testing.T, roots []string) {
 		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 			return nil
 		})
-		require.NoError(t, err, "Setup: listing input files for caching handling")
+		require.NoError(t, err, "Setup: Error when listing input files for caching handling")
 	}
 }

--- a/internal/testutils/files.go
+++ b/internal/testutils/files.go
@@ -282,3 +282,15 @@ func ignoreDconfDB(src string, entries []os.FileInfo) []string {
 	}
 	return r
 }
+
+// markForTestCache list all root directories/files so that they are marked in the test cache.
+func markForTestCache(t *testing.T, roots []string) {
+	t.Helper()
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			return nil
+		})
+		require.NoError(t, err, "Setup: listing input files for caching handling")
+	}
+}

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -1,0 +1,30 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// MarkRustFilesForTestCache marks all rust files and related content to be in the Go test caching infra.
+func MarkRustFilesForTestCache(t *testing.T) {
+	t.Helper()
+
+	markForTestCache(t, []string{"src", "testdata", "Cargo.toml", "Cargo.lock"})
+}
+
+// CanRunRustTests returns if we can run rust tests via cargo on this machine.
+// It returns if code coverage is supported.
+func CanRunRustTests() (canRun, withCoverage bool) {
+	d, err := exec.Command("cargo", "--version").CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't run Rust tests, cargo can't be executed: %v\n", err)
+		return false, false
+	}
+
+	// TODO: detect nightly for code coverage
+	fmt.Println(string(d))
+
+	return true, false
+}

--- a/internal/testutils/rust.go
+++ b/internal/testutils/rust.go
@@ -1,10 +1,18 @@
 package testutils
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MarkRustFilesForTestCache marks all rust files and related content to be in the Go test caching infra.
@@ -15,16 +23,152 @@ func MarkRustFilesForTestCache(t *testing.T) {
 }
 
 // CanRunRustTests returns if we can run rust tests via cargo on this machine.
-// It returns if code coverage is supported.
-func CanRunRustTests() (canRun, withCoverage bool) {
+// It checks for code coverage report if supported.
+func CanRunRustTests(coverageWanted bool) (err error) {
 	d, err := exec.Command("cargo", "--version").CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't run Rust tests, cargo can't be executed: %v\n", err)
-		return false, false
+		return fmt.Errorf("cargo can't be executed: %w", err)
 	}
 
-	// TODO: detect nightly for code coverage
-	fmt.Println(string(d))
+	if !coverageWanted {
+		return nil
+	}
 
-	return true, false
+	// Only nightly has code coverage enabled
+	supportCoverage := strings.Contains(string(d), "nightly")
+	if !supportCoverage {
+		return errors.New("coverage is requested but your cargo/rust version does not support it (needs nightly)")
+	}
+
+	// We need grcov for coverage report. However, even --help or --version creates a profile file in current directory.
+	// Doing that in a temporary directory we clean then.
+	tmp, err := os.MkdirTemp("", "grcov-test-*")
+	if err != nil {
+		return fmt.Errorf("can't create temporary directory to test grcov: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	cmd := exec.Command("grcov", "--version")
+	cmd.Env = append(os.Environ(), "LLVM_PROFILE_FILE="+tmp)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("grcov is needed for coverage report and can't be executed: %w", err)
+	}
+
+	return nil
+}
+
+// TrackRustCoverage returns environment variables and target directory so that following commands
+// runs with code coverage enabled.
+// Note that for developping purposes and avoiding keeping building the rust program dependencies,
+// TEST_RUST_TARGET environment variable can be set to keep iterative build artifacts.
+// This then allow coverage to run in parallel, as each subprocess will have its own environment.
+// You will need to call MergeCoverages() after m.Run().
+// If code coverage is not enabled, it still returns an empty slice, but the target can be used.
+func TrackRustCoverage(t *testing.T) (env []string, target string) {
+	t.Helper()
+
+	target = os.Getenv("TEST_RUST_TARGET")
+	if target == "" {
+		target = t.TempDir()
+	}
+
+	testGoCoverage := TrackTestCoverage(t)
+	if testGoCoverage == "" {
+		return []string{}, target
+	}
+
+	coverDir := filepath.Dir(testGoCoverage)
+
+	t.Cleanup(func() {
+		rustJSONCoverage := testGoCoverage + ".json"
+		// nolint:gosec // G204 we define what we cover ourself
+		cmd := exec.Command("grcov", coverDir,
+			"--binary-path", filepath.Join(target, "debug"),
+			"-s", ".", "--ignore-not-existing",
+			"-t", "covdir",
+			"-o", rustJSONCoverage)
+		cmd.Env = append(os.Environ(), "LLVM_PROFILE_FILE="+coverDir)
+		err := cmd.Run()
+		require.NoError(t, err, "Teardown: could not convert coverage to json format")
+
+		// Load our converted JSON profile.
+		var results map[string]interface{}
+		d, err := os.ReadFile(rustJSONCoverage)
+		require.NoError(t, err, "Teardown: can't read our json coverage file")
+		err = json.Unmarshal(d, &results)
+		require.NoError(t, err, "Teardown: decode our json coverage file")
+
+		// This is the destination file for rust coverage in go format.
+		outF, err := os.Create(testGoCoverage)
+		require.NoErrorf(t, err, "Teardown: failed opening output golang compatible cover file: %s", err)
+		defer func() { assert.NoError(t, outF.Close(), "Teardown: can’t close golang compatible cover file") }()
+
+		// Scan our results to write to it.
+		scan(t, results, fqdnToPath(t, ""), outF)
+	})
+
+	return []string{"RUSTFLAGS=-Cinstrument-coverage", "LLVM_PROFILE_FILE=" + filepath.Join(coverDir, "rust-%p-%m.profraw")}, target
+}
+
+// scan iterates over children files and folders elements recursively.
+func scan(t *testing.T, results map[string]interface{}, p string, w io.Writer) {
+	t.Helper()
+
+	// Scan a file.
+	r := results["coverage"]
+	if r != nil {
+		res, ok := r.([]interface{})
+		if !ok {
+			t.Fatalf("%v for coverage report is not a slice of floats in interface", r)
+		}
+		convertRustFileResult(t, res, p, w)
+		return
+	}
+
+	// Scan children files or folders.
+	r = results["children"]
+	if r != nil {
+		res, ok := r.(map[string]interface{})
+		if !ok {
+			t.Fatalf("children %v is not a map of data", r)
+		}
+		// Iterate over files or dir.
+		for elem, subResults := range res {
+			// We are not interesting in other code than ours
+			if elem == "/" {
+				continue
+			}
+
+			res, ok := subResults.(map[string]interface{})
+			// Skip summary coverage-related data
+			if !ok {
+				continue
+			}
+			scan(t, res, filepath.Join(p, elem), w)
+		}
+	}
+}
+
+// convertRustFileResult converts rust-formatted coverage content to go one and writes it to w.
+func convertRustFileResult(t *testing.T, results []interface{}, p string, w io.Writer) {
+	t.Helper()
+
+	for l, r := range results {
+		v, ok := r.(float64)
+		if !ok {
+			t.Fatalf("%v for coverage report is not a float", r)
+		}
+		var covered string
+		switch v {
+		case -1:
+			continue
+		case 0:
+			covered = "0"
+		default:
+			// We are in mode set, so don’t count the number of runs
+			covered = "1"
+		}
+		// We are doing line coverage and we don’t have the source line handy. Set it to 9999 then.
+		writeGoCoverageLine(t, w, p, l+1, 9999, covered)
+	}
 }


### PR DESCRIPTION
* Hook up running rust tests from go test command, with proper detection and cache handling.
* Add Rust -> Go coverage convertion support
 Similarly to python, add helpers for Rust code coverage.
 Refactor some helper functions to minimize the API surface and make it more idiomatic.
* Add coverage to Rust mount handler
 In addition to call the coverage file, we need to mark src/ as a Go package for the Go coverage tool picking it up.

Note that this has been tested with Rust modules in subdirectories of src/ too.

DEENG-513