### PR TITLE
Fix special characters in domain

### DIFF
--- a/internal/ad/backends/sss/sss.go
+++ b/internal/ad/backends/sss/sss.go
@@ -69,7 +69,7 @@ func New(ctx context.Context, c Config, bus *dbus.Conn) (s SSS, err error) {
 	}
 
 	domainDbus := bus.Object(consts.SSSDDbusRegisteredName,
-		dbus.ObjectPath(filepath.Join(consts.SSSDDbusBaseObjectPath, strings.ReplaceAll(domain, ".", "_2e"))))
+		dbus.ObjectPath(filepath.Join(consts.SSSDDbusBaseObjectPath, domainToObjectPath(domain))))
 
 	// Server url
 	staticServerURL := cfg.Section(fmt.Sprintf("domain/%s", sssdDomain)).Key("ad_server").String()
@@ -148,4 +148,20 @@ func (sss SSS) Config() string {
 	return fmt.Sprintf(`Current backend is SSSD
 Configuration: %s
 Cache: %s`, sss.config.Conf, sss.config.CacheDir)
+}
+
+// domainToObjectPath converts a potential dbus object path string to valid hexadecimal-based equivalent as encoded
+// in sssd.
+// The separator in the domain is converted too.
+func domainToObjectPath(s string) string {
+	var r string
+	for _, c := range s {
+		if (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') || c == '_' {
+			r += string(c)
+			continue
+		}
+		r = fmt.Sprintf("%s_%02x", r, c)
+	}
+	return r
 }

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -54,7 +54,7 @@ func TestSSSD(t *testing.T) {
 		"No sssd conf loads the default": {sssdConf: ""},
 
 		// ServerURL error cases (this doesn't fail New)
-		"ServerURL() does not fail when we do not need an active server":        {sssdConf: "domain-without-dbus.example.com-with-server"},
+		"ServerURL() does not fail when we do not need an active server":        {sssdConf: "active-server-err.example.com-with-server"},
 		"Error returned by ServerURL() on no config nor active server provided": {sssdConf: "no-active-server-example.com"},
 		"Error returned by ServerURL() when calls is erroring out":              {sssdConf: "active-server-err.example.com"},
 

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -44,8 +44,9 @@ func TestSSSD(t *testing.T) {
 		"Is not online": {sssdConf: "offline-example.com"},
 
 		// Special cases
-		"SSSd domain can not match ad domain": {sssdConf: "domain-no-match-addomain"},
-		"Default domain suffix is read":       {sssdConf: "example.com-with-default-domain-suffix"},
+		"Can handle special DNS domain characters": {sssdConf: "special-characters.example.com"},
+		"SSSd domain can not match ad domain":      {sssdConf: "domain-no-match-addomain"},
+		"Default domain suffix is read":            {sssdConf: "example.com-with-default-domain-suffix"},
 
 		// Special cases for config parameters
 		"Regular config, with cache dir": {sssdConf: "example.com", sssdCacheDir: "/some/specific/cachedir"},
@@ -145,7 +146,7 @@ func (s sssdbus) ActiveServer(_ string) (string, *dbus.Error) {
 	if s.activeServerErr {
 		return "", dbus.NewError("something.sssd.Error", []interface{}{"Active Server dbus call Error"})
 	}
-	return "dynamic_active_server." + strings.ReplaceAll(s.endpoint, "_2e", "."), nil
+	return "dynamic_active_server." + strings.ReplaceAll(strings.ReplaceAll(s.endpoint, "_2e", "."), "_2d", "-"), nil
 }
 
 func (s sssdbus) IsOnline() (bool, *dbus.Error) {
@@ -198,6 +199,9 @@ func TestMain(m *testing.M) {
 	for _, s := range []sssdbus{
 		{
 			endpoint: "example_2ecom",
+		},
+		{
+			endpoint: "special_2dcharacters_2eexample_2ecom",
 		},
 		{
 			endpoint: "offline_2eexample_2ecom",

--- a/internal/ad/backends/sss/testdata/configs/active-server-err.example.com-with-server
+++ b/internal/ad/backends/sss/testdata/configs/active-server-err.example.com-with-server
@@ -1,0 +1,6 @@
+[sssd]
+domains = activeservererr.example.com
+
+[domain/activeservererr.example.com]
+ad_domain = activeservererr.example.com
+ad_server = mystaticserver.example.com

--- a/internal/ad/backends/sss/testdata/configs/domain-without-dbus.example.com-with-server
+++ b/internal/ad/backends/sss/testdata/configs/domain-without-dbus.example.com-with-server
@@ -1,6 +1,0 @@
-[sssd]
-domains = domain-without-dbus.example
-
-[domain/domain-without-dbus.example]
-ad_domain = domain-without-dbus.example
-ad_server = mystaticserver.example.com

--- a/internal/ad/backends/sss/testdata/configs/special-characters.example.com
+++ b/internal/ad/backends/sss/testdata/configs/special-characters.example.com
@@ -1,0 +1,5 @@
+[sssd]
+domains = special-characters.example.com
+
+[domain/special-characters.example.com]
+ad_domain = special-characters.example.com

--- a/internal/ad/backends/sss/testdata/golden/TestSSSD/Can_handle_special_DNS_domain_characters
+++ b/internal/ad/backends/sss/testdata/golden/TestSSSD/Can_handle_special_DNS_domain_characters
@@ -1,0 +1,9 @@
+* Domain(): special-characters.example.com
+* ServerURL(): ldap://dynamic_active_server.special-characters.example.com
+* IsOnline(): true
+* HostKrb5CCNAME(): /var/lib/sss/db/ccache_SPECIAL-CHARACTERS.EXAMPLE.COM
+* DefaultDomainSuffix(): special-characters.example.com
+* Config():
+Current backend is SSSD
+Configuration: testdata/configs/special-characters.example.com
+Cache: /var/lib/sss/db

--- a/internal/ad/backends/sss/testdata/golden/TestSSSD/Error_returned_by_ServerURL()_and_IsOnline()_when_DBUS_has_no_object
+++ b/internal/ad/backends/sss/testdata/golden/TestSSSD/Error_returned_by_ServerURL()_and_IsOnline()_when_DBUS_has_no_object
@@ -1,6 +1,6 @@
 * Domain(): domain-without-dbus.example
-* ServerURL ERROR(): error while trying to look up AD server address on SSSD for "domain-without-dbus.example": dbus: invalid message: invalid path name
-* IsOnline ERROR(): failed to retrieve offline state from SSSD: dbus: invalid message: invalid path name
+* ServerURL ERROR(): error while trying to look up AD server address on SSSD for "domain-without-dbus.example": Object does not implement the interface 'org.freedesktop.sssd.infopipe.Domains.Domain'
+* IsOnline ERROR(): failed to retrieve offline state from SSSD: Object does not implement the interface 'org.freedesktop.sssd.infopipe.Domains.Domain'
 * HostKrb5CCNAME(): /var/lib/sss/db/ccache_DOMAIN-WITHOUT-DBUS.EXAMPLE
 * DefaultDomainSuffix(): domain-without-dbus.example
 * Config():

--- a/internal/ad/backends/sss/testdata/golden/TestSSSD/ServerURL()_does_not_fail_when_we_do_not_need_an_active_server
+++ b/internal/ad/backends/sss/testdata/golden/TestSSSD/ServerURL()_does_not_fail_when_we_do_not_need_an_active_server
@@ -1,9 +1,9 @@
-* Domain(): domain-without-dbus.example
+* Domain(): activeservererr.example.com
 * ServerURL(): ldap://mystaticserver.example.com
-* IsOnline ERROR(): failed to retrieve offline state from SSSD: dbus: invalid message: invalid path name
-* HostKrb5CCNAME(): /var/lib/sss/db/ccache_DOMAIN-WITHOUT-DBUS.EXAMPLE
-* DefaultDomainSuffix(): domain-without-dbus.example
+* IsOnline(): true
+* HostKrb5CCNAME(): /var/lib/sss/db/ccache_ACTIVESERVERERR.EXAMPLE.COM
+* DefaultDomainSuffix(): activeservererr.example.com
 * Config():
 Current backend is SSSD
-Configuration: testdata/configs/domain-without-dbus.example.com-with-server
+Configuration: testdata/configs/active-server-err.example.com-with-server
 Cache: /var/lib/sss/db


### PR DESCRIPTION
Fix special characters in domain name when using sssd backend.

We need to convert them to valid dbus path objects, which is more restrictive than what DNS permits. We were only doing . -> _2e conversion. Now, we base on the sssd implementation itself in https://fossies.org/linux/sssd/src/sbus/sbus_opath.c to provide the same implementation logic on a valid domain.

Refresh some existing test cases, making some more relevant and add a new one for the new use case. As those are more special cases, let’s keep them covered inside the backend itself, and we still have a general one (only covering the dot conversion) in the integration tests.

DEENG-529