### PR TITLE
Stabilize integration test coverage

### DIFF
--- a/cmd/adsysd/integration_tests/adsysctl_policy_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_policy_test.go
@@ -822,6 +822,7 @@ func TestPolicyUpdate(t *testing.T) {
 				tc.systemAnswer = "polkit_yes"
 			}
 			systemAnswer(t, tc.systemAnswer)
+			testutils.PythonCoverageToGoFormat(t, filepath.Join(rootProjectDir, "internal/ad/adsys-gpolist"), true)
 
 			adsysDir := t.TempDir()
 
@@ -1064,8 +1065,6 @@ func setupSubprocessForTest(t *testing.T, currentUser string, otherUsers ...stri
 
 	err := exec.Command("pkg-config", "--exists", "nss_wrapper").Run()
 	require.NoError(t, err, "libnss-wrapper is not installed on disk, either skip integration tests or install it")
-
-	testutils.PythonCoverageToGoFormat(t, filepath.Join(rootProjectDir, "internal/ad/adsys-gpolist"), true)
 
 	var subArgs []string
 	// We are going to only reexec ourself: only take options (without -run)

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -50,6 +51,9 @@ func TrackTestCoverage(t *testing.T) (testCoverFile string) {
 	testCoverFile = fmt.Sprintf("%s.%s", coverAbsPath, strings.ReplaceAll(t.Name(), "/", "_"))
 	coveragesToMergeMu.Lock()
 	defer coveragesToMergeMu.Unlock()
+	if slices.Contains(coveragesToMerge, testCoverFile) {
+		t.Fatalf("Trying to adding a second time %q to the list of file to cover. This will create some overwrite and thus, should be only called once", testCoverFile)
+	}
 	coveragesToMerge = append(coveragesToMerge, testCoverFile)
 
 	return testCoverFile

--- a/internal/testutils/coverage.go
+++ b/internal/testutils/coverage.go
@@ -48,7 +48,9 @@ func TrackTestCoverage(t *testing.T) (testCoverFile string) {
 	coverAbsPath, err := filepath.Abs(goMainCoverProfile)
 	require.NoError(t, err, "Setup: can't transform go cover profile to absolute path")
 
-	testCoverFile = fmt.Sprintf("%s.%s", coverAbsPath, strings.ReplaceAll(t.Name(), "/", "_"))
+	testCoverFile = fmt.Sprintf("%s.%s", coverAbsPath, strings.ReplaceAll(
+		strings.ReplaceAll(t.Name(), "/", "_"),
+		"\\", "_"))
 	coveragesToMergeMu.Lock()
 	defer coveragesToMergeMu.Unlock()
 	if slices.Contains(coveragesToMerge, testCoverFile) {

--- a/internal/testutils/pythoncoverage.go
+++ b/internal/testutils/pythoncoverage.go
@@ -88,7 +88,7 @@ exec python3-coverage run -a %s $@
 		coverDir := pythonCoverageFile + ".annotated"
 		// #nosec G204 - we have a const for coverageCmd
 		out, err := exec.Command(coverageCmd, "annotate", "-d", coverDir, "--include", tracedFile).CombinedOutput()
-		require.NoErrorf(t, err, "Teardown: can’t combine python coverage: %v", string(out))
+		require.NoErrorf(t, err, "Teardown: can’t combine python coverage: %s", out)
 
 		// Convert to golang compatible cover format
 		// The file will be transform with char_hexadecimal_filename_ext,cover if there is any / in the name.

--- a/internal/testutils/pythoncoverage.go
+++ b/internal/testutils/pythoncoverage.go
@@ -84,8 +84,8 @@ exec python3-coverage run -a %s $@
 			return
 		}
 
-		// Convert to text format
-		coverDir := filepath.Dir(testGoCoverage)
+		// Convert to text format in a subdirectory named after the python coverage file.
+		coverDir := pythonCoverageFile + ".annotated"
 		// #nosec G204 - we have a const for coverageCmd
 		out, err := exec.Command(coverageCmd, "annotate", "-d", coverDir, "--include", tracedFile).CombinedOutput()
 		require.NoErrorf(t, err, "Teardown: can’t combine python coverage: %v", string(out))


### PR DESCRIPTION
* Prevent coverage tracking to be called twice in the same test
* Annotate python coverage file in a subdirectory
* Move python file tracking per test

DEENG-531
Fixes: #500 