### PR TITLE
Fix output github action deprecation warning

### DIFF
--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -77,7 +77,7 @@ jobs:
               releases="${releases}'ubuntu:${r}'"
           done
 
-          echo "::set-output name=matrix::{\"releases\":[${releases}]}"
+          echo "matrix={\"releases\":[${releases}]}" >> $GITHUB_OUTPUT
 
   collect-releases:
     name: Collect supported keys on each releases
@@ -186,7 +186,7 @@ jobs:
       - name: Get output branch for branch name
         id: get-branch-name
         shell: bash
-        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Get version of golanci-lint to use
         id: cilint-version-fetch
         # This handles "require foo version" and "require (\nfoo version\n)"" formats
-        run: echo "::set-output name=version::$(grep golangci-lint tools/go.mod | rev | cut -f1 -d' ' | rev)"
+        run: echo "version=$(grep golangci-lint tools/go.mod | rev | cut -f1 -d' ' | rev)" >> $GITHUB_OUTPUT
       - name: Code formatting, vet, static checker Security…
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
set-output is going to be deprecated as per
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. Use the new syntax.