### PR TITLE
Improvements on the handling of hostnames to account for FQDN

### DIFF
--- a/cmd/adsysd/client/policy.go
+++ b/cmd/adsysd/client/policy.go
@@ -344,10 +344,7 @@ func (a *App) update(isComputer, updateAll bool, target, krb5cc string) error {
 			return err
 		}
 		// for malconfigured machines where /proc/sys/kernel/hostname returns the fqdn and not only the machine name, strip it
-		if i := strings.Index(hostname, "."); i > 0 {
-			hostname = hostname[:i]
-		}
-		target = hostname
+		target, _, _ = strings.Cut(hostname, ".")
 	}
 
 	// Update for current user

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -565,6 +565,7 @@ func (ad *AD) NormalizeTargetName(ctx context.Context, target string, objectClas
 	return target, nil
 }
 
+// Hostname returns the hostname of the current client.
 func (ad *AD) Hostname() string {
 	return ad.hostname
 }

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -565,7 +565,7 @@ func (ad *AD) NormalizeTargetName(ctx context.Context, target string, objectClas
 	return target, nil
 }
 
-// Hostname returns the hostname of the current client.
+// Hostname returns the normalized hostname of the current client.
 func (ad *AD) Hostname() string {
 	return ad.hostname
 }

--- a/internal/ad/internal_test.go
+++ b/internal/ad/internal_test.go
@@ -24,6 +24,9 @@ func TestFetch(t *testing.T) {
 
 	bus := testutils.NewDbusConn(t)
 
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
+
 	tests := map[string]struct {
 		adDomain               string
 		gpos                   []string
@@ -276,7 +279,7 @@ func TestFetch(t *testing.T) {
 			}
 
 			adc, err := New(context.Background(), bus,
-				mock.Backend{},
+				mock.Backend{}, hostname,
 				WithCacheDir(dest), WithRunDir(rundir), withoutKerberos())
 
 			require.NoError(t, err, "Setup: cannot create ad object")
@@ -388,6 +391,8 @@ func TestFetchWithUnreadableFile(t *testing.T) {
 	t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
 	bus := testutils.NewDbusConn(t)
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
 
 	// Prepare downloadables with unreadable file.
 	// Defer will work after all tests are done because we don’t run it in parallel
@@ -409,7 +414,7 @@ func TestFetchWithUnreadableFile(t *testing.T) {
 
 			dest, rundir := t.TempDir(), t.TempDir()
 
-			adc, err := New(context.Background(), bus, mock.Backend{},
+			adc, err := New(context.Background(), bus, mock.Backend{}, hostname,
 				WithCacheDir(dest), WithRunDir(rundir), withoutKerberos())
 			require.NoError(t, err, "Setup: cannot create ad object")
 
@@ -442,6 +447,8 @@ func TestFetchTweakSysvolCacheDir(t *testing.T) {
 	t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
 	bus := testutils.NewDbusConn(t)
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
 
 	tests := map[string]struct {
 		removeSysvolCacheDir     bool
@@ -457,7 +464,7 @@ func TestFetchTweakSysvolCacheDir(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
 			dest, rundir := t.TempDir(), t.TempDir()
-			adc, err := New(context.Background(), bus, mock.Backend{},
+			adc, err := New(context.Background(), bus, mock.Backend{}, hostname,
 				WithCacheDir(dest), WithRunDir(rundir), withoutKerberos())
 			require.NoError(t, err, "Setup: cannot create ad object")
 
@@ -481,10 +488,12 @@ func TestFetchOneGPOWhileParsingItConcurrently(t *testing.T) {
 	t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
 	bus := testutils.NewDbusConn(t)
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
 
 	dest, rundir := t.TempDir(), t.TempDir()
 
-	adc, err := New(context.Background(), bus, mock.Backend{},
+	adc, err := New(context.Background(), bus, mock.Backend{}, hostname,
 		WithCacheDir(dest), WithRunDir(rundir), withoutKerberos())
 	require.NoError(t, err, "Setup: cannot create ad object")
 
@@ -530,10 +539,12 @@ func TestParseGPOConcurrent(t *testing.T) {
 	t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
 	bus := testutils.NewDbusConn(t)
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
 
 	dest, rundir := t.TempDir(), t.TempDir()
 
-	adc, err := New(context.Background(), bus, mock.Backend{},
+	adc, err := New(context.Background(), bus, mock.Backend{}, hostname,
 		WithCacheDir(dest), WithRunDir(rundir), withoutKerberos())
 	require.NoError(t, err, "Setup: cannot create ad object")
 

--- a/internal/adsysservice/policy.go
+++ b/internal/adsysservice/policy.go
@@ -3,7 +3,6 @@ package adsysservice
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/ubuntu/adsys"
 	"github.com/ubuntu/adsys/internal/ad"
@@ -40,10 +39,8 @@ func (s *Service) UpdatePolicy(r *adsys.UpdatePolicyRequest, stream adsys.Servic
 	}
 
 	if r.GetIsComputer() || r.GetAll() {
-		hostname, err := os.Hostname()
-		if err != nil {
-			return err
-		}
+		hostname := s.adc.Hostname()
+
 		err = s.updatePolicyFor(stream.Context(), true, hostname, ad.ComputerObject, "")
 
 		if r.GetAll() {
@@ -89,11 +86,7 @@ func (s *Service) DumpPolicies(r *adsys.DumpPoliciesRequest, stream adsys.Servic
 	}
 
 	// hostname policy display is allowed to all users
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
-	}
-	if target != hostname {
+	if target != s.adc.Hostname() {
 		if err := s.authorizer.IsAllowedFromContext(context.WithValue(stream.Context(), authorizer.OnUserKey, target),
 			actions.ActionPolicyDump); err != nil {
 			return err

--- a/internal/policies/manager_test.go
+++ b/internal/policies/manager_test.go
@@ -27,6 +27,9 @@ func TestApplyPolicies(t *testing.T) {
 	require.NoError(t, err, "Setup: can not create dummy systemctl")
 	testutils.Setenv(t, "PATH", fmt.Sprintf("%s:%s", bin, os.Getenv("PATH")))
 
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
+
 	bus := testutils.NewDbusConn(t)
 
 	subscriptionDbus := bus.Object(consts.SubscriptionDbusRegisteredName,
@@ -91,6 +94,7 @@ func TestApplyPolicies(t *testing.T) {
 			}()
 
 			m, err := policies.NewManager(bus,
+				hostname,
 				policies.WithCacheDir(cacheDir),
 				policies.WithRunDir(runDir),
 				policies.WithDconfDir(dconfDir),
@@ -250,7 +254,7 @@ func TestDumpPolicies(t *testing.T) {
 			t.Parallel()
 
 			cacheDir, runDir := t.TempDir(), t.TempDir()
-			m, err := policies.NewManager(bus, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
+			m, err := policies.NewManager(bus, hostname, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
 			require.NoError(t, err, "Setup: couldn’t get a new policy manager")
 
 			err = os.MkdirAll(filepath.Join(cacheDir, policies.PoliciesCacheBaseName), 0750)
@@ -326,7 +330,7 @@ func TestLastUpdateFor(t *testing.T) {
 			t.Parallel()
 
 			cacheDir, runDir := t.TempDir(), t.TempDir()
-			m, err := policies.NewManager(bus, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
+			m, err := policies.NewManager(bus, hostname, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
 			require.NoError(t, err, "Setup: couldn’t get a new policy manager")
 
 			err = os.MkdirAll(filepath.Join(cacheDir, policies.PoliciesCacheBaseName), 0750)
@@ -363,6 +367,9 @@ func TestGetSubscriptionState(t *testing.T) {
 	subscriptionDbus := bus.Object(consts.SubscriptionDbusRegisteredName,
 		dbus.ObjectPath(consts.SubscriptionDbusObjectPath))
 
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Setup: failed to get hostname for tests.")
+
 	tests := map[string]struct {
 		status bool
 
@@ -385,7 +392,7 @@ func TestGetSubscriptionState(t *testing.T) {
 			}()
 
 			cacheDir, runDir := t.TempDir(), t.TempDir()
-			m, err := policies.NewManager(bus, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
+			m, err := policies.NewManager(bus, hostname, policies.WithCacheDir(cacheDir), policies.WithRunDir(runDir))
 			require.NoError(t, err, "Setup: couldn’t get a new policy manager")
 
 			got := m.GetSubscriptionState(context.Background())


### PR DESCRIPTION
Fixes a bug where FQDN hostnames were being treated as the account name to be queried for when searching for GPOs. Addresses issue #523.

DEENG-538