### PR TITLE
Change user mount manager behavior: now it stops and errors out when it's not able to set up the policy.

### DIFF
--- a/internal/policies/mount/entries_test.go
+++ b/internal/policies/mount/entries_test.go
@@ -53,4 +53,6 @@ protocol://domain.com/mountpath
 	},
 
 	"errored entry": {Value: "protocol://domain.com/mountpath", Err: fmt.Errorf("some error")},
+
+	"entry with badly formatted value": {Value: "protocol//domain.com/mountpath"},
 }

--- a/internal/policies/mount/internal_test.go
+++ b/internal/policies/mount/internal_test.go
@@ -20,6 +20,8 @@ func TestParseEntryValues(t *testing.T) {
 
 	tests := map[string]struct {
 		entry string
+
+		wantErr bool
 	}{
 		// Single entry cases.
 		"parse values from entry with one value":        {entry: "entry with one value"},
@@ -40,10 +42,15 @@ func TestParseEntryValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := parseEntryValues(EntriesForTests[tc.entry])
+			got, err := parseEntryValues(EntriesForTests[tc.entry])
+			if tc.wantErr {
+				require.Error(t, err, "Expected an error but got none.")
+				return
+			}
+			require.NoError(t, err, "Expected no error but got one.")
 
 			gotPath := t.TempDir()
-			err := os.WriteFile(filepath.Join(gotPath, "parsed_values"), []byte(strings.Join(got, "\n")+"\n"), 0600)
+			err = os.WriteFile(filepath.Join(gotPath, "parsed_values"), []byte(strings.Join(got, "\n")+"\n"), 0600)
 			require.NoError(t, err, "Setup: Failed to write the result")
 
 			goldenPath := filepath.Join("testdata", t.Name(), "golden")

--- a/internal/policies/mount/mount.go
+++ b/internal/policies/mount/mount.go
@@ -144,7 +144,12 @@ func (m *Manager) applyUserMountsPolicy(ctx context.Context, username string, en
 		return fmt.Errorf(i18n.G("can't create user directory %q for %q: %v"), objectPath, username, err)
 	}
 
-	s := strings.Join(parseEntryValues(entry), "\n")
+	parsedValues, err := parseEntryValues(entry)
+	if err != nil {
+		return err
+	}
+
+	s := strings.Join(parsedValues, "\n")
 	if s == "" {
 		if err = m.cleanupMountsFile(ctx, u.Uid); err != nil {
 			return err
@@ -160,9 +165,11 @@ func (m *Manager) applyUserMountsPolicy(ctx context.Context, username string, en
 }
 
 // parseEntryValues parses the entry value, trimming whitespaces and removing duplicates.
-func parseEntryValues(entry entry.Entry) (p []string) {
+func parseEntryValues(entry entry.Entry) (p []string, err error) {
+	defer decorate.OnError(&err, i18n.G("failed to parse entry values"))
+
 	if entry.Err != nil {
-		return nil
+		return nil, fmt.Errorf(i18n.G("entry is errored: %v"), entry.Err)
 	}
 
 	seen := make(map[string]struct{})
@@ -171,11 +178,29 @@ func parseEntryValues(entry entry.Entry) (p []string) {
 		if _, ok := seen[v]; ok || v == "" {
 			continue
 		}
+
+		if err := checkValue(v); err != nil {
+			return nil, err
+		}
+
 		p = append(p, v)
 		seen[v] = struct{}{}
 	}
 
-	return p
+	return p, nil
+}
+
+// checkValue checks if the entry value respects the defined formatting directive: <protocol>://<hostname-or-ip>/<shared-path>.
+func checkValue(value string) error {
+	// Removes the kerberos auth tag, if it exists
+	tmp := strings.TrimPrefix(value, "[krb5]")
+
+	// Value left: protocol://<hostname-or-ip>/<shared-path>
+	if _, hostnameAndPath, found := strings.Cut(tmp, ":"); !found || !strings.HasPrefix(hostnameAndPath, "//") {
+		return fmt.Errorf(i18n.G("entry %q is badly formatted"), value)
+	}
+
+	return nil
 }
 
 // writeFileWithUIDGID writes the content into the specified path and changes its ownership to the specified uid/gid.

--- a/internal/policies/mount/mount_test.go
+++ b/internal/policies/mount/mount_test.go
@@ -98,9 +98,11 @@ func TestApplyPolicy(t *testing.T) {
 		"error when user has invalid gid":                                                            {userReturnedGID: "invalid", wantErr: true},
 		"error when users-userDir has invalid permissions":                                           {readOnlyUsersDir: true, wantErr: true},
 		"error when mounts file path already exists as a directory":                                  {pathAlreadyExists: true, wantErr: true},
+		"error when entry is errored":                                                                {entries: []string{"errored entry"}, wantErr: true},
 		"error when cleaning up user policy with invalid user":                                       {entries: []string{"no entries"}, objectName: "dont exist", wantErr: true},
 		"error when cleaning up user policy with no entries and path already exists as a directory":  {entries: []string{"no entries"}, pathAlreadyExists: true, wantErr: true},
 		"error when cleaning up user policy with empty entry and path already exists as a directory": {entries: []string{"entry with no value"}, pathAlreadyExists: true, wantErr: true},
+		"error when applying policy with entry containing badly formatted value":                     {entries: []string{"entry with badly formatted value"}, wantErr: true},
 	}
 
 	u, err := user.Current()


### PR DESCRIPTION
After some discussion, it was clear that some manager behavior would need to change. We needed to have a clearer definition of when a manager should fail and why.
Now, the mount manager will error out whenever it fails to set up the require files for the mounting process.