### PR TITLE
Wrap apparmor calls with smbsafe

### DIFF
--- a/internal/policies/apparmor/apparmor.go
+++ b/internal/policies/apparmor/apparmor.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
 	"github.com/ubuntu/adsys/internal/policies/entry"
+	"github.com/ubuntu/adsys/internal/smbsafe"
 	"golang.org/x/exp/slices"
 )
 
@@ -229,6 +230,8 @@ func (m *Manager) applyMachinePolicy(ctx context.Context, e entry.Entry, apparmo
 		// #nosec G204 - We are in control of the arguments
 		cmd := exec.CommandContext(ctx, apparmorParserCmd[0], apparmorParserCmd[1:]...)
 		cmd.Dir = m.apparmorDir
+		smbsafe.WaitExec()
+		defer smbsafe.DoneExec()
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf(i18n.G("failed to load apparmor rules: %w\n%s"), err, string(out))
 		}
@@ -299,6 +302,8 @@ func (m *Manager) applyUserPolicy(ctx context.Context, e entry.Entry, apparmorPa
 	// #nosec G204 - We are in control of the arguments
 	cmd := exec.CommandContext(ctx, apparmorParserCmd[0], apparmorParserCmd[1:]...)
 	cmd.Dir = m.apparmorDir
+	smbsafe.WaitExec()
+	defer smbsafe.DoneExec()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Restore the old content
 		var restoreErr error
@@ -396,7 +401,9 @@ func (m *Manager) policiesFromFiles(ctx context.Context, profiles []string) (pol
 	cmd.Dir = m.apparmorDir
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
+	smbsafe.WaitExec()
 	err = cmd.Run()
+	smbsafe.DoneExec()
 	if err != nil {
 		return nil, fmt.Errorf(i18n.G("failed to get apparmor policies: %w\n%s"), err, errb.String())
 	}
@@ -450,6 +457,8 @@ func (m *Manager) unloadPolicies(ctx context.Context, policies []string) error {
 		}
 	}()
 
+	smbsafe.WaitExec()
+	defer smbsafe.DoneExec()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf(i18n.G("failed to unload apparmor policies: %w\n%s"), err, string(out))
 	}


### PR DESCRIPTION
This is a requirement for executed commands because `libsmbclient` overrides sigchild without setting `SA_ONSTACK`, so any `cmd.Wait()` would segfault when ran concurrently with this.

Closes #542 / DEENG-541