### PR TITLE
Adding cifs-utils and curlftpfs as dependencies for the adsys package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,8 @@ Depends: ${shlibs:Depends},
          sssd,
          sssd-dbus,
          apparmor,
+         cifs-utils,
+         curlftpfs,
 Recommends: ${misc:Recommends},
             ubuntu-advantage-desktop-daemon,
 Description: ${source:Synopsis}


### PR DESCRIPTION
I might be completely wrong, but I think that we only need to add some dependencies to the package and then the packaging for the system mounts is done.