### PR TITLE
Install missing packages for auto-updates workflow

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -7,6 +7,11 @@ on:
       - po/*
       - README.md
 
+env:
+  apt_dependencies: >-
+    ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev
+    libwbclient-dev pkg-config protobuf-compiler python3-coverage samba sudo
+
 jobs:
   update-po:
     name: Update po files
@@ -63,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y libsmbclient-dev gcc pkg-config
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y ${{ env.apt_dependencies }}
       # Checkout code with git
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
It appears that we are building adsys not just in the qa.yaml workflow, so take the dependencies from there and install them in the auto-updates workflow as well.

Failing job: https://github.com/ubuntu/adsys/actions/runs/3694144643/jobs/6254993551