### PR TITLE
Vendored sources autoupdate action

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -105,11 +105,11 @@ jobs:
         run: |
           git push origin auto-update-readme-cli-ref:main
 
-  update-vendored-sources:
+  update-rust-vendored-sources:
     name: Update XS-Vendored-Sources-Rust on debian/control
     runs-on: ubuntu-latest
     container: 
-      image: ubuntu:23.04
+      image: ubuntu:rolling
     steps:
       - name: Install dependencies
         run: |
@@ -124,7 +124,9 @@ jobs:
           cargo vendor vendor_rust/
       - name: Update XS-Vendored-Sources-Rust
         run: |
-          OUTPUT=$((CARGO_VENDOR_DIR=vendor_rust/ /usr/share/cargo/bin/dh-cargo-vendored-sources 2>&1 ||:) | grep XS-Vendored-Sources-Rust:)
+          set -eu
+        
+          OUTPUT=$((CARGO_VENDOR_DIR=vendor_rust/ /usr/share/cargo/bin/dh-cargo-vendored-sources 2>&1 || true) | grep XS-Vendored-Sources-Rust:)
           if [ -z "$OUTPUT" ]; then
               exit 0
           fi
@@ -134,21 +136,22 @@ jobs:
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
 
-      - run: git config --global --add safe.directory /__w/adsys/adsys
+      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
+        run: git config --global --add safe.directory /__w/adsys/adsys
 
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}
         # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
         uses: peter-evans/create-pull-request@v5-beta
         with:
-          commit-message: Auto update debian/control file
-          title: Auto update debian/control file
+          commit-message: Auto update Rust vendored sources in debian/control file
+          title: Auto update Rust vendored sources in debian/control file
           labels: control, automated pr
           body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
-          branch: auto-update-debian-control
+          branch: auto-update-rust-vendored-sources
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push branch
         if: ${{ env.modified == 'true' }}
         # TODO: Change this when merging it into main
         run: |
-          git push origin auto-update-debian-control:user-mount-handler
+          git push origin auto-update-rust-vendored-sources:user-mount-handler

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -144,8 +144,8 @@ jobs:
         # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
         uses: peter-evans/create-pull-request@v5-beta
         with:
-          commit-message: Auto update Rust vendored sources in debian/control file
-          title: Auto update Rust vendored sources in debian/control file
+          commit-message: Auto update Rust vendored sources in debian/control
+          title: Auto update Rust vendored sources in debian/control
           labels: control, automated pr
           body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
           branch: auto-update-rust-vendored-sources

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -107,6 +107,7 @@ jobs:
 
   update-rust-vendored-sources:
     name: Update XS-Vendored-Sources-Rust on debian/control
+    needs: update-readme-clid-ref
     runs-on: ubuntu-latest
     container: 
       image: ubuntu:rolling

--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -1,11 +1,13 @@
-name: Update translation and readme in main branch automatically
+name: Update translation, readme and debian/control in main branch automatically
 on:
   push:
-    branches:
-      - main
+    # Uncomment this when merging into main
+    # branches:
+    #   - main
     paths-ignore:
       - po/*
       - README.md
+      - debian/control
 
 jobs:
   update-po:
@@ -102,3 +104,51 @@ jobs:
         if: ${{ env.modified == 'true' }}
         run: |
           git push origin auto-update-readme-cli-ref:main
+
+  update-vendored-sources:
+    name: Update XS-Vendored-Sources-Rust on debian/control
+    runs-on: ubuntu-latest
+    container: 
+      image: ubuntu:23.04
+    steps:
+      - name: Install dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt update
+          DEBIAN_FRONTEND=noninteractive apt install -y cargo dh-cargo git
+      - uses: actions/checkout@v3
+        with:
+          # TODO: Change this when merging it into main
+          ref: user-mount-handler
+      - name: Vendoring the dependencies
+        run: |
+          cargo vendor vendor_rust/
+      - name: Update XS-Vendored-Sources-Rust
+        run: |
+          OUTPUT=$((CARGO_VENDOR_DIR=vendor_rust/ /usr/share/cargo/bin/dh-cargo-vendored-sources 2>&1 ||:) | grep XS-Vendored-Sources-Rust:)
+          if [ -z "$OUTPUT" ]; then
+              exit 0
+          fi
+
+          sed -i "s/^XS-Vendored-Sources-Rust:.*/$OUTPUT/" debian/control
+
+          echo "modified=true" >> $GITHUB_ENV
+        shell: bash
+
+      - run: git config --global --add safe.directory /__w/adsys/adsys
+
+      - name: Create Pull Request
+        if: ${{ env.modified == 'true' }}
+        # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
+        uses: peter-evans/create-pull-request@v5-beta
+        with:
+          commit-message: Auto update debian/control file
+          title: Auto update debian/control file
+          labels: control, automated pr
+          body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
+          branch: auto-update-debian-control
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push branch
+        if: ${{ env.modified == 'true' }}
+        # TODO: Change this when merging it into main
+        run: |
+          git push origin auto-update-debian-control:user-mount-handler

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Build-Depends: debhelper-compat (= 13),
                libwbclient-dev,
 Standards-Version: 4.5.1
 XS-Go-Import-Path: github.com/ubuntu/adsys
+XS-Vendored-Sources-Rust: 
 Homepage: https://github.com/ubuntu/adsys
 Description: AD SYStem integration
  ADSys is an AD SYStem tool to integrate GPOs with a linux system.


### PR DESCRIPTION
Adding action to auto update the XS-Vendored-Sources-Rust field in debian/control.

Some lines are commented and changed in order to test the action behavior, but will be fixed before merging.

Readme checks are failing because of the absence of https://github.com/ubuntu/adsys/commit/573eb07bc4729e8bb3a5429b19f09cbe509e8948, which fixed the dependencies of the action (will stop once the branch is rebased onto main).