### PR TITLE
Fix object name in mount tests

### DIFF
--- a/internal/policies/mount/mount_test.go
+++ b/internal/policies/mount/mount_test.go
@@ -235,7 +235,7 @@ func TestApplyPolicy(t *testing.T) {
 			require.NoError(t, err, "Setup: Failed to create manager for the tests.")
 			m.SetSystemCtlCmd(mockSystemCtlCmd(t, tc.firstSystemCtlFailingArgs...))
 
-			err = m.ApplyPolicy(context.Background(), "ubuntu", tc.isComputer, entries)
+			err = m.ApplyPolicy(context.Background(), tc.objectName, tc.isComputer, entries)
 			if tc.wantErr {
 				require.Error(t, err, "ApplyPolicy should have returned an error but did not")
 				return


### PR DESCRIPTION
This was always called with "ubuntu" - causing some tests to fail on autopkgtests, specifically the user not found/invalid user tests, as autopkgtests run under the "ubuntu" user.