### PR TITLE
Replace `gopkg.in/yaml.v2` with `gopkg.in/yaml.v3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/ini.v1 v1.67.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -74,4 +73,5 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/config/watchd/testdata/TestWriteConfig/golden/with_nested_config_path
+++ b/internal/config/watchd/testdata/TestWriteConfig/golden/with_nested_config_path
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- dir1
-- dir2
+    - dir1
+    - dir2

--- a/internal/config/watchd/testdata/TestWriteConfig/golden/with_relative_config_path
+++ b/internal/config/watchd/testdata/TestWriteConfig/golden/with_relative_config_path
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- dir1
-- dir2
+    - dir1
+    - dir2

--- a/internal/config/watchd/watchd.go
+++ b/internal/config/watchd/watchd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ubuntu/adsys/internal/decorate"
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // CmdName is the binary name for the daemon.

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_default_config.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_default_config.yaml
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo/bar
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo/bar
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_directory_as_config_input.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_directory_as_config_input.yaml
@@ -1,3 +1,3 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_dot_directories_is_normalized.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_dot_directories_is_normalized.yaml
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- #ABSPATH#
-- #ABSPATH#/foo/bar
+    - #ABSPATH#
+    - #ABSPATH#/foo/bar

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_double_dot_directories_is_normalized.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_double_dot_directories_is_normalized.yaml
@@ -1,3 +1,3 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_duplicate_directories.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_duplicate_directories.yaml
@@ -1,5 +1,5 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo
-- #ABSPATH#/foo/bar
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo
+    - #ABSPATH#/foo/bar
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_fresh_config_in_current_directory.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_fresh_config_in_current_directory.yaml
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo/bar
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo/bar
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_fresh_config_in_nested_directory.yaml
+++ b/internal/watchdtui/testdata/TestInteractiveInput/golden/submit_with_fresh_config_in_nested_directory.yaml
@@ -1,4 +1,4 @@
 verbose: 0
 dirs:
-- #ABSPATH#/foo/bar
-- #ABSPATH#/foo/baz
+    - #ABSPATH#/foo/bar
+    - #ABSPATH#/foo/baz

--- a/internal/watchdtui/watchdtui_test.go
+++ b/internal/watchdtui/watchdtui_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ubuntu/adsys/internal/testutils"
 	"github.com/ubuntu/adsys/internal/watchdservice"
 	"github.com/ubuntu/adsys/internal/watchdtui"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (


### PR DESCRIPTION
Right now, we are using two YAML packages
1. gopkg.in/yaml.v2
2. gopkg.in/yaml.v3

We can keep only the latest `gopkg.in/yaml.v3` package.