### PR TITLE
Replace `gopkg.in/yaml.v2` with `gopkg.in/yaml.v3`

### DIFF
--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var update bool


### PR DESCRIPTION
> @didrocks This commit https://github.com/ubuntu/adsys/commit/6c457685ca6b09daa2b7d1483a6e3ba5d1c3959d was merged an hour ago and another `"gopkg.in/yaml.v2"` slipped in :sweat_smile: . Sorry I didn't notice this

_Originally posted by @Juneezee in https://github.com/ubuntu/adsys/issues/581#issuecomment-1384207636_

> @Juneezee sorry about that, we just merged a big test refactor that caused this. Feel free to open an additional PR tackling that case.

_Originally posted by @GabrielNagy in https://github.com/ubuntu/adsys/issues/581#issuecomment-1384248249_
            