### PR TITLE
Clean-up the packaging scripts in `user-mount-handler`

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -162,3 +162,66 @@ jobs:
         # TODO: Change this when merging it into main
         run: |
           git push origin auto-update-rust-vendored-sources:user-mount-handler
+
+  update-fake-checksum-file:
+    name: 'Update the fake checksum file at d/cargo-checksum.json'
+    needs: update-readme-clid-ref
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # TODO: Change this when merging it into main
+          ref: user-mount-handler
+      - name: 'Install GitHub script dependencies'
+        run: npm install toml
+      - name: 'Update the checksum file'
+        uses: actions/github-script@v5
+        id: update-checksum
+        with:
+          script: |
+            const toml = require("toml");
+            const fs = require("node:fs");
+            const checksum_path = "./debian/cargo-checksum.json";
+            /** @typedef LockEntry @prop {string} name @prop {string} checksum @prop {string} version */
+            /** Read and parse the lock file
+            * @param {string} path
+            * @returns {any} */
+            function readLock(path) {
+              const lock = fs.readFileSync(path, { encoding: "utf-8" });
+              return toml.parse(lock);
+            }
+
+            const lockfile = readLock("./Cargo.lock");
+            /** @type {LockEntry?} */ const sd_block = lockfile.package.find(
+              (/** @type {LockEntry} */ x) => x.name === "system-deps"
+            );
+            if (!sd_block) throw new Error("system-deps not found in the lock file");
+            const old_cksum_file = require(checksum_path);
+            if (old_cksum_file.package === sd_block.checksum) {
+                console.info("Checksum is up-to-date. No update needed.");
+                return false;
+            }
+            const new_cksum_file =
+              JSON.stringify({
+                package: sd_block.checksum,
+                files: {},
+              }) + "\n";
+            fs.writeFileSync(checksum_path, new_cksum_file);
+            console.info("Checksum file updated.");
+            return true;
+      - name: Create Pull Request
+        if: ${{ steps.update-checksum.outputs.result == 'true' }}
+        # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
+        uses: peter-evans/create-pull-request@v5-beta
+        with:
+          commit-message: Auto update Rust vendored sources checksums
+          title: Auto update Rust vendored sources checksums
+          labels: control, automated pr
+          body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
+          branch: auto-update-rust-checksum
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push branch
+        if: ${{ steps.update-checksum.outputs.result == 'true' }}
+        # TODO: Change this when merging it into main
+        run: |
+          git push origin auto-update-rust-checksum:user-mount-handler

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ debian/adsys-windows
 /adsysd
 /adsysctl
 /adsys.yaml
+
+# GitHub CI temporary files
+node_modules
+package-lock.json
+package.json

--- a/debian/cargo-checksum.json
+++ b/debian/cargo-checksum.json
@@ -1,1 +1,1 @@
-{"package":"Could not get crate checksum","files":{}}
+{"package":"2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff","files":{}}

--- a/debian/rules
+++ b/debian/rules
@@ -50,6 +50,9 @@ override_dh_auto_clean:
 	# system-deps crate includes an empty .a file which is filtered out when
 	# building the source package and cargo gets confused when trying to verify
 	# integrity. So we just put in an empty checksum file instead.
+	# The checksum in the file comes from the Cargo.lock file under the `system-deps`
+	# dependency segment. This fake checksum file needs to be updated after each
+	# adsys update.
 	if [ ! -d $(CARGO_VENDOR_DIR)/ ]; then \
 		$(CARGO) vendor $(CARGO_VENDOR_DIR); \
 		cp debian/cargo-checksum.json $(CARGO_VENDOR_DIR)/system-deps/.cargo-checksum.json; \
@@ -58,12 +61,6 @@ override_dh_auto_clean:
 	# That last line above is to warn whoever's doing the packaging that they
 	# need to update the Vendored-Sources field. The initial packaging work
 	# didn't include said field since the vendoring is done on the fly.
-
-	# After the package is built, we need to restore the original lockfile to keep it in line 
-	# with upstream.
-	if [ -e Cargo.lock.bkp ]; then \
-		mv Cargo.lock.bkp Cargo.lock; \
-	fi
 
 override_dh_auto_configure:
 	dh_auto_configure
@@ -81,50 +78,8 @@ override_dh_auto_build:
 	# Build on linux only adsysd itself, and not generator or Windows binaries
 	DH_GOLANG_BUILDPKG=github.com/ubuntu/adsys/cmd/adsysd dh_auto_build
 
-	# Debian Native packages remove some .a files and ends up changing some of the dependencies
-	# checksums. To still be able to build, we have to trick Cargo into thinking we don't have
-	# a lockfile and make it regenerate another based on our vendored dependencies.
-	if [ ! -e Cargo.lock.bkp ]; then \
-		mv Cargo.lock Cargo.lock.bkp; \
-	fi
-
-	# Everything must be executed in a single command in order to store the status before restoring
-	# the backup and exiting with $$STATUS.																					
-	DEB_HOST_GNU_TYPE=$(DEB_HOST_GNU_TYPE) \
-	DEB_HOST_RUST_TYPE=$(DEB_HOST_RUST_TYPE) \
-	CARGO_HOME=$(CURDIR)/debian/cargo_home \
-	$(CARGO) build --release --all; \
-	STATUS=$$?; \
-    \
-	if [ -e Cargo.lock.bkp ]; then \
-		mv Cargo.lock.bkp Cargo.lock; \
-	fi; \
-    \
-	if [ $$STATUS -ne 0 ]; then \
-		exit $$STATUS; \
-	fi
-
 override_dh_auto_test:
-	# Debian Native packages remove some .a files and ends up changing some of the dependencies
-	# checksums. To still be able to build, we have to trick Cargo into thinking we don't have
-	# a lockfile and make it regenerate another based on our vendored dependencies.
-	if [ ! -e Cargo.lock.bkp ]; then \
-		mv Cargo.lock Cargo.lock.bkp; \
-	fi
-
-	# Everything must be executed in a single command in order to store the status before restoring
-	# the backup and exiting with $$STATUS.																					
-	dh_auto_test --buildsystem=cargo -- test --all; \
-	STATUS=$$?; \
-    \
-	if [ -e Cargo.lock.bkp ]; then \
-		mv Cargo.lock.bkp Cargo.lock; \
-	fi; \
-    \
-	if [ $$STATUS -ne 0 ]; then \
-		exit $$STATUS; \
-	fi
-
+	dh_auto_test --buildsystem=cargo -- test --all
 	dh_auto_test
 
 # Build the Windows executables for adwatchd where applicable
@@ -135,12 +90,21 @@ endif
 override_dh_auto_install:
 	dh_auto_install -- --no-source
 
+	# Here we utilise a logical flaw in the cargo wrapper to our advantage:
+	# when specifying DEB_CARGO_CRATE_IN_REGISTRY=1, the wrapper will
+	# avoid adding the `--path` option, so that we can specify it ourselves
+	DEB_HOST_GNU_TYPE=$(DEB_HOST_GNU_TYPE) \
+	DEB_HOST_RUST_TYPE=$(DEB_HOST_RUST_TYPE) \
+	CARGO_HOME=$(CURDIR)/debian/cargo_home \
+	DEB_CARGO_CRATE=adsys_mount_0.1.0 \
+	DEB_CARGO_CRATE_IN_REGISTRY=1 \
+	DESTDIR=$(CURDIR)/debian/tmp \
+        $(CARGO) install --path $(ADSYS_MOUNT)
 	# Currently doesn't work because of https://github.com/rust-lang/cargo/issues/4101
 	# combined with a lack of flexibility in the cargo wrapper. That means we
 	# have to do it manually (with the build split out in dh_auto_build for good
 	# measure, even though dh-cargo does it all in the install step)
-	# dh_auto_install --buildsystem=cargo
-	cp target/$(DEB_HOST_RUST_TYPE)/release/adsys_mount debian/tmp/usr/bin
+	# dh_auto_install --buildsystem=cargo -- --path $(ADSYS_MOUNT)
 
 	# PAM configuration
 	mkdir -p debian/tmp/usr/share/pam


### PR DESCRIPTION
This pull request utilizes a behavior in the Debian Cargo wrapper to workaround several issues where the Rust crate can not be compiled correctly due to non-overridable options in the said wrapper.

Also, use the real checksum in the facade manifest to avoid the need for updating `Cargo.lock` file.