### PR TITLE
Replacing safe directory work around

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -121,6 +121,9 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt update
           DEBIAN_FRONTEND=noninteractive apt install -y cargo dh-cargo git
       - uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}
+          set-safe-directory: true
       - name: Vendoring the dependencies
         run: |
           cargo vendor vendor_rust/
@@ -138,9 +141,6 @@ jobs:
 
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
-
-      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
-        run: git config --global --add safe.directory /__w/adsys/adsys
 
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,9 +23,10 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ${{ env.apt_dependencies }}
-      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
-        run: git config --global --add safe.directory /__w/adsys/adsys
       - uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}
+          set-safe-directory: true
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
@@ -178,9 +179,10 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt update
           DEBIAN_FRONTEND=noninteractive apt install -y ${{ env.apt_dependencies }}
-      - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
-        run: git config --global --add safe.directory /__w/adsys/adsys
       - uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}
+          set-safe-directory: true
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod


### PR DESCRIPTION
Replaces all the manual git config calls with the attribute `set-safe-directory` of actions/checkout.

Closes #596 