### PR TITLE
Replacing os.WriteFile after init in the config tests

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ func Init(name string, cmd cobra.Command, vip *viper.Viper, configChanged func(r
 		log.Infof(context.Background(), "Using configuration file: %v", vip.ConfigFileUsed())
 		vip.WatchConfig()
 		vip.OnConfigChange(func(e fsnotify.Event) {
-			if e.Op != fsnotify.Write {
+			if e.Op != fsnotify.Write && e.Op != fsnotify.Create {
 				return
 			}
 			log.Infof(context.Background(), "Config file %q changed. Reloading.", e.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -312,8 +312,16 @@ func TestInit(t *testing.T) {
 				callbackPhase = 2
 				phaseMu.Unlock()
 
-				err = os.WriteFile(filepath.Join(configDir, prefix+".yaml"), []byte(tc.changeConfigWith), 0600)
-				require.NoError(t, err, "Setup: failed to write initial config file")
+				// fsnotify docs states that truncating a file will also trigger a Write event, which means that the callback can be triggered
+				// before the file contents are properly written. In order to avoid that, we must manually open the file and write the new content
+				// to it to avoid truncating the file and triggering the event too early.
+				configFile, err := os.OpenFile(filepath.Join(configDir, prefix+".yaml"), os.O_RDWR|os.O_CREATE, os.ModePerm)
+				require.NoError(t, err, "Setup: failed to open config file")
+				defer configFile.Close()
+				_, err = configFile.WriteString(tc.changeConfigWith)
+				require.NoError(t, err, "Setup: failed to write new content to config file")
+				configFile.Close()
+
 				// Let’s force a sync to make sure the file is written on disk
 				syscall.Sync()
 				select {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,6 +96,8 @@ func TestInit(t *testing.T) {
 		notInConfigDir     bool
 		changeConfigWith   string
 
+		directlyChangeConfigFile bool
+
 		subcommand             bool
 		configFlagOnSubcommand bool
 
@@ -149,8 +151,12 @@ func TestInit(t *testing.T) {
 		},
 
 		// Configuration changes support
-		"Configuration changed": {
-			configFileContent: "value: filecontentvalue", changeConfigWith: "value: filecontentvaluerefreshed",
+		"Configuration changed directly": {
+			configFileContent: "value: filecontentvalue", changeConfigWith: "value: filecontentvaluerefreshed", directlyChangeConfigFile: true,
+			want: "filecontentvaluerefreshed", wantCallbackCalled: 2,
+		},
+		"Configuration file overwritten": {
+			configFileContent: "value: filecontentvalue", changeConfigWith: "value: filecontentvaluerefreshed", directlyChangeConfigFile: false,
 			want: "filecontentvaluerefreshed", wantCallbackCalled: 2,
 		},
 		"Configuration file created after Init() is not taken into account": {
@@ -312,15 +318,22 @@ func TestInit(t *testing.T) {
 				callbackPhase = 2
 				phaseMu.Unlock()
 
-				// fsnotify docs states that truncating a file will also trigger a Write event, which means that the callback can be triggered
-				// before the file contents are properly written. In order to avoid that, we must manually open the file and write the new content
-				// to it to avoid truncating the file and triggering the event too early.
-				configFile, err := os.OpenFile(filepath.Join(configDir, prefix+".yaml"), os.O_RDWR|os.O_CREATE, os.ModePerm)
-				require.NoError(t, err, "Setup: failed to open config file")
-				defer configFile.Close()
-				_, err = configFile.WriteString(tc.changeConfigWith)
-				require.NoError(t, err, "Setup: failed to write new content to config file")
-				configFile.Close()
+				if tc.directlyChangeConfigFile {
+					// fsnotify docs states that truncating a file will also trigger a Write event, which means that the callback can be triggered
+					// before the file contents are properly written. In order to avoid that, we must manually open the file and write the new content
+					// to it to avoid truncating the file and triggering the event too early.
+					configFile, err := os.OpenFile(filepath.Join(configDir, prefix+".yaml"), os.O_RDWR|os.O_CREATE, os.ModePerm)
+					require.NoError(t, err, "Setup: failed to open config file")
+					defer configFile.Close()
+					_, err = configFile.WriteString(tc.changeConfigWith)
+					require.NoError(t, err, "Setup: failed to write new content to config file")
+					configFile.Close()
+				} else {
+					err := os.WriteFile(filepath.Join(configDir, prefix+".new"), []byte(tc.changeConfigWith), 0600)
+					require.NoError(t, err, "Setup: failed to write .new config file")
+					err = os.Rename(filepath.Join(configDir, prefix+".new"), filepath.Join(configDir, prefix+".yaml"))
+					require.NoError(t, err, "Setup: failed to rename .new file to the expected name")
+				}
 
 				// Let’s force a sync to make sure the file is written on disk
 				syscall.Sync()


### PR DESCRIPTION
Viper relies on fsnotify to trigger a config update. However, the fsnotify docs state that the Write event is also triggered by truncating the file. This means that the update callback was being called too soon and we were unmarshaling the file contents before they were properly written.
To avoid this problem, the os.WriteFile call had to be replaced and now we manually open the file, write to it and then close it to properly flush the changes and only then have the callback triggered.

DEENG-607