### PR TITLE
Updating Rust auto-update actions

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -1,4 +1,4 @@
-name: Update translation, readme and debian/control in main branch automatically
+name: Update translation, readme and Rust packaging files in main branch automatically
 on:
   push:
     branches:
@@ -109,114 +109,75 @@ jobs:
         run: |
           git push origin auto-update-readme-cli-ref:main
 
-  update-rust-vendored-sources:
-    name: Update XS-Vendored-Sources-Rust on debian/control
+  update-rust-packaging:
+    name: Update packaging related Rust files
     needs: update-readme-clid-ref
     runs-on: ubuntu-latest
+    # Right now, ubuntu 22.04 does not have the dh-cargo-vendored-sources script that is needed to
+    # run this job, so we need to run it inside a rolling container to get the latest version possible.
+    # This should be updated as soon as the dh-cargo version with the mentioned script gets ported to
+    # 22.04 or ubuntu-latest changes to a more recent version.
     container:
       image: ubuntu:rolling
     steps:
       - name: Install dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive apt update
-          DEBIAN_FRONTEND=noninteractive apt install -y cargo dh-cargo git
+          DEBIAN_FRONTEND=noninteractive apt install -y cargo dh-cargo git jq
       - uses: actions/checkout@v3
-      - name: Vendoring the dependencies
+        with:
+          ref: main
+      - name: Vendor the dependencies
         run: |
           cargo vendor vendor_rust/
       - name: Update XS-Vendored-Sources-Rust
         run: |
           set -eu
-
           export CARGO_VENDOR_DIR=vendor_rust/
           VENDORED_SOURCES=$(/usr/share/cargo/bin/dh-cargo-vendored-sources 2>&1 || true)
           OUTPUT=$(echo "$VENDORED_SOURCES" | grep ^XS-Vendored-Sources-Rust: || true)
           if [ -z "$OUTPUT" ]; then
+            echo "XS-Vendored-Sources-Rust is up to date. No change is needed.";
             exit 0
           fi
           sed -i "s/^XS-Vendored-Sources-Rust:.*/$OUTPUT/" debian/control
-
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
-
+      - name: Update the fake checksum file
+        run: |
+          set -eu
+          # Reads the checksum of both files
+          FAKE_CHECKSUM=$(cat debian/cargo-checksum.json | jq .package)
+          CRATE_CHECKSUM=$(cat vendor_rust/system-deps/.cargo-checksum.json | jq .package)
+          if [ "${FAKE_CHECKSUM}" == "${CRATE_CHECKSUM}" ]; then
+            echo "debian/cargo-checksum.json is up to date. No change is needed.";
+            exit 0
+          fi
+          # Formats in a way where we can replace the line using sed
+          FMT_CHECKSUM="\"package\": ${CRATE_CHECKSUM},"
+          # Replaces the fake checksum with the correct value
+          sed -i "s/\"package\":.*/${FMT_CHECKSUM}/" debian/cargo-checksum.json
+          echo "modified=true" >>$GITHUB_ENV
+        shell: bash
+      # Since we run this job in a container, we need to manually add the safe directory due to some
+      # issues between actions/checkout and actions/runner, which seem to be triggered by multiple
+      # causes (e.g. https://github.com/actions/runner-images/issues/6775, https://github.com/actions/checkout/issues/1048#issuecomment-1356485556).
       - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
         run: git config --global --add safe.directory /__w/adsys/adsys
-
       - name: Create Pull Request
         if: ${{ env.modified == 'true' }}
-        # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
-        uses: peter-evans/create-pull-request@v4
+        # V5 Beta needed because of some problems between this action and container runners.
+        # See more on: https://github.com/peter-evans/create-pull-request/issues/1170
+        uses: peter-evans/create-pull-request@v5-beta
         with:
-          commit-message: Auto update Rust vendored sources in debian/control
-          title: Auto update Rust vendored sources in debian/control
+          commit-message: Auto update packaging related Rust files
+          title: Auto update packaging related Rust files
           labels: control, automated pr
           body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
-          branch: auto-update-rust-vendored-sources
+          branch: auto-update-rust-packaging
+          delete-branch: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Push branch
         if: ${{ env.modified == 'true' }}
         run: |
-          git push origin auto-update-rust-vendored-sources:main
-
-  update-fake-checksum-file:
-    name: 'Update the fake checksum file at d/cargo-checksum.json'
-    needs: update-rust-vendored-sources
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y git nodejs
-      - uses: actions/checkout@v3
-      - name: 'Install GitHub script dependencies'
-        run: npm install -D toml @types/node
-      - name: 'Update the checksum file'
-        uses: actions/github-script@v6
-        id: update-checksum
-        with:
-          script: |
-            const toml = require("toml");
-            const fs = require("fs");
-            const checksum_path = "./debian/cargo-checksum.json";
-            /** @typedef LockEntry @prop {string} name @prop {string} checksum @prop {string} version */
-            /** Read and parse the lock file
-            * @param {string} path
-            * @returns {any} */
-            function readLock(path) {
-              const lock = fs.readFileSync(path, { encoding: "utf-8" });
-              return toml.parse(lock);
-            }
-
-            const lockfile = readLock("./Cargo.lock");
-            /** @type {LockEntry?} */ const sd_block = lockfile.package.find(
-              (/** @type {LockEntry} */ x) => x.name === "system-deps"
-            );
-            if (!sd_block) throw new Error("system-deps not found in the lock file");
-            const old_cksum_file = require(checksum_path);
-            if (old_cksum_file.package === sd_block.checksum) {
-                console.info("Checksum is up-to-date. No update needed.");
-                return false;
-            }
-            const new_cksum_file =
-              JSON.stringify({
-                package: sd_block.checksum,
-                files: {},
-              }) + "\n";
-            fs.writeFileSync(checksum_path, new_cksum_file);
-            console.info("Checksum file updated.");
-            return true;
-      - name: Create Pull Request
-        if: ${{ steps.update-checksum.outputs.result == 'true' }}
-        # V5 Beta needed because of https://github.com/peter-evans/create-pull-request/issues/1170
-        uses: peter-evans/create-pull-request@v4
-        with:
-          commit-message: Auto update Rust vendored sources checksums
-          title: Auto update Rust vendored sources checksums
-          labels: control, automated pr
-          body: "[Auto-generated pull request](https://github.com/ubuntu/adsys/actions/workflows/auto-updates.yaml) by GitHub Action"
-          branch: auto-update-rust-checksum
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push branch
-        if: ${{ steps.update-checksum.outputs.result == 'true' }}
-        run: |
-          git push origin auto-update-rust-checksum:main
+          git push origin auto-update-rust-packaging:main

--- a/debian/cargo-checksum.json
+++ b/debian/cargo-checksum.json
@@ -1,1 +1,4 @@
-{"package":"2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff","files":{}}
+{
+    "package": "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff",
+    "files": {}
+}


### PR DESCRIPTION
As we spotted in aad-auth, the update-fake-checksum job had some issues and we had to rewrite it. This PR applies the same changes made in aad-auth to adsys, to avoid future problems. More detailed information can be seen on the commit messages and on https://github.com/ubuntu/aad-auth/pull/140