### PR TITLE
Adding guideline docs to policy managers

### DIFF
--- a/internal/policies/apparmor/apparmor.go
+++ b/internal/policies/apparmor/apparmor.go
@@ -1,4 +1,21 @@
 // Package apparmor provides a manager to apply apparmor policies.
+//
+// The policy manager first checks if apparmor_parser is available
+// (file exists and is executable) and proceeds differently if these
+// requirements are not met, depending on whether there are configured entries in
+// the GPO:
+// - no entries: a warning is logged and the manager returns without error
+// - entries: the manager returns an error if apparmor_parser is not found
+//
+// Next, if we found no entries to apply (either to them not existing or being
+// disabled), we attempt to unload all rules managed by ADSys.
+//
+// If there are entries to apply, based on the object type (machine or user), we
+// attempt to apply them. This process is more clearly outlined in the
+// ApplyPolicy function documentation.
+//
+// If any errors occur during the policy apply process, the manager will attempt
+// to restore the initial state of the system before returning an error.
 package apparmor
 
 import (

--- a/internal/policies/gdm/gdm.go
+++ b/internal/policies/gdm/gdm.go
@@ -1,4 +1,8 @@
-// Package gdm is the policy manager for gdm entry types. It’s using the dconf parser for gdm user.
+// Package gdm is the policy manager for gdm entry types.
+//
+// This policy manager applies dconf policies to the gdm user. It will create a system-db:gdm database
+// with the requested key=value pairs specified in the policy. For more information, refer to the
+// dconf manager documentation.
 package gdm
 
 import (

--- a/internal/policies/manager.go
+++ b/internal/policies/manager.go
@@ -1,3 +1,26 @@
+// Package policies - Policy manager guidelines
+//
+// ADSys is expected to apply configuration policies, not enforce them. We are responsible for
+// properly configuring those policies and set up the machine to apply them, but we can not ensure that
+// they will be executed as this relies on lots of variables and system functionalities.
+// As such, policy managers are expected to only prevent authentication when something goes wrong
+// during the configuration of the policies, whilst ensuring that the user will be warned should a
+// configuration fail to execute.
+//
+// We should prevent authentication on errors such as:
+//   - failed to copy the policy requested assets to the machine;
+//   - failed to parse policy configuration values;
+//   - failed to write the requested files on disk;
+//   - missing required auxiliar binary to set up the policy (e.g. apparmor_parser, dconf);
+//
+// We should only warn the user on errors such as:
+//   - systemd unit failed to start due to some system error;
+//   - copied asset failed to be executed due to own misconfiguration;
+//   - script failed during execution;
+//   - requested shared folder does not exist and, as such, can not be mounted;
+//
+// This is supposed to be a guideline, rather than a rule. Therefore, some of these errors can be
+// interchangeable depending on which policy is being applied.
 package policies
 
 import (

--- a/internal/policies/mount/mount.go
+++ b/internal/policies/mount/mount.go
@@ -1,7 +1,16 @@
-// Package mount implements the manager responsible to handle the file sharing
-// policy of adsys, parsing the GPO rules and setting up the mount process for
-// the requested drives. User mounts will be handled by a systemd user service and
-// computer mounts will be handled directly by systemd, via mount units.
+// Package mount provides the policy manager to handle file sharing policies.
+//
+// The manager behavior differs depending on the object type:
+//   - System mounts: Systemd mount units are created to handle the mount process of the
+//     requested shared locations;
+//   - User mounts:   The policy values are parsed into a mounts file that will handled by a
+//     helper binary that will mount the shared locations using gio.
+//
+// Should the manager fail to write the required assets, an error will be returned.
+// However, if the manager setup all the required steps, it's up to the correctness of the specified
+// entries values and gvfs to mount the requested shared drives.
+// Should an error occur during this step, it will be logged (in the system journal for the system
+// or in the adsys-user-mounts.service for the user).
 package mount
 
 import (
@@ -25,20 +34,6 @@ import (
 	"github.com/ubuntu/adsys/internal/smbsafe"
 	"golang.org/x/exp/slices"
 )
-
-/*
-
-The mount policy for adsys works as follows:
-
-Should the manager fail to setup the policy with the requested entries and its values,
-an error will be returned and the login is prevented.
-
-However, if the manager creates the files needed and setup all the required steps,
-it's up to the correctness of the specified entries values and gvfs to mount the
-requested shared drives. Should an error occur during this step, adsys will log it
-without preventing the authentication.
-
-*/
 
 type options struct {
 	systemctlCmd  []string

--- a/internal/policies/privilege/privilege.go
+++ b/internal/policies/privilege/privilege.go
@@ -1,4 +1,18 @@
-// Package privilege is the policy manager for privilege escalation (sudo and polkit) entry types.
+// Package privilege is the policy manager for privilege escalation entry types.
+//
+// This manager allows (and denies) privilege escalation on the client by configuring sudo and polkit
+// files. In order to do that, it modifies 2 files (one for sudo and one for polkit) and their default
+// locations are, respectively:
+//   - /etc/sudoers.d/99-adsys-privilege-enforcement
+//   - /etc/polkit-1/localauthority.conf.d/99-adsys-privilege-enforcement
+//
+// This is an all or nothing type of policy and, therefore, requires a lot of attention during setup.
+// If the policy is setup improperly, users could end up with too much (or too little) privilege,
+// which could compromise the safety and/or usability of the machine until the policy gets updated.
+// If the policy is set without any value (or it's disabled) the files are removed and the default
+// privilege configuration is restored.
+// Should the manager fail to create the files with the requested values, it will return an error and
+// authentication will be prevented.
 package privilege
 
 import (

--- a/internal/policies/scripts/scripts.go
+++ b/internal/policies/scripts/scripts.go
@@ -1,6 +1,16 @@
 // Package scripts is the policy manager for machine and user script entry types.
 //
-// It handles also the script assets themselves.
+// This manager configures the scripts that will be executed in the following steps:
+//   - machine: startup and shutdown;
+//   - user: login and logout;
+//
+// The manager will download the requested assets and set up the scripts to be executed during the
+// mentioned steps. The machine scripts will be executed by ADSys itself and the user ones will be
+// handled by systemd through user units.
+// If the manager fail to download and find the required assets, the applying process will fail and
+// authentication will be prevented. ADSys ensures that the scripts will be executed at the correct
+// time and in the correct order, but it does not account for the correctness of the scripts.
+// If a script returns an error, it will be logged, but authentication will not be prevented.
 package scripts
 
 import (
@@ -23,13 +33,6 @@ import (
 	"github.com/ubuntu/adsys/internal/policies/entry"
 	"github.com/ubuntu/adsys/internal/smbsafe"
 )
-
-/*
-	Notes:
-
-	scripts are executed to control machine startup and shutdown, and user login/logout.
-	We rely on systemd units to manage them and only control the execution of the machine startup one.
-*/
 
 const (
 	inSessionFlag = ".running"


### PR DESCRIPTION
When creating the mount policy manager, we realized that we needed a defined way of handling errors in the managers. Which errors should prevent authentication? Which errors should only be warned to the user?

After some discussion, we defined an expected general behavior that all managers should have and this must documented on the general manager, defined in manager.go

Closes #528
DEENG-539