### PR TITLE
Fixing crates checksum issue

### DIFF
--- a/.github/workflows/auto-updates.yaml
+++ b/.github/workflows/auto-updates.yaml
@@ -143,22 +143,6 @@ jobs:
           sed -i "s/^XS-Vendored-Sources-Rust:.*/$OUTPUT/" debian/control
           echo "modified=true" >> $GITHUB_ENV
         shell: bash
-      - name: Update the fake checksum file
-        run: |
-          set -eu
-          # Reads the checksum of both files
-          FAKE_CHECKSUM=$(cat debian/cargo-checksum.json | jq .package)
-          CRATE_CHECKSUM=$(cat vendor_rust/system-deps/.cargo-checksum.json | jq .package)
-          if [ "${FAKE_CHECKSUM}" == "${CRATE_CHECKSUM}" ]; then
-            echo "debian/cargo-checksum.json is up to date. No change is needed.";
-            exit 0
-          fi
-          # Formats in a way where we can replace the line using sed
-          FMT_CHECKSUM="\"package\": ${CRATE_CHECKSUM},"
-          # Replaces the fake checksum with the correct value
-          sed -i "s/\"package\":.*/${FMT_CHECKSUM}/" debian/cargo-checksum.json
-          echo "modified=true" >>$GITHUB_ENV
-        shell: bash
       # Since we run this job in a container, we need to manually add the safe directory due to some
       # issues between actions/checkout and actions/runner, which seem to be triggered by multiple
       # causes (e.g. https://github.com/actions/runner-images/issues/6775, https://github.com/actions/checkout/issues/1048#issuecomment-1356485556).

--- a/debian/cargo-checksum.json
+++ b/debian/cargo-checksum.json
@@ -1,4 +1,0 @@
-{
-    "package": "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff",
-    "files": {}
-}

--- a/debian/rules
+++ b/debian/rules
@@ -47,16 +47,24 @@ override_dh_auto_clean:
 	dh_auto_clean --buildsystem=cargo
 	# Create the vendor directory when building the source package
 	[ -d vendor/ ] || go mod vendor
-	# system-deps crate includes an empty .a file which is filtered out when
-	# building the source package and cargo gets confused when trying to verify
-	# integrity. So we just put in an empty checksum file instead.
-	# The checksum in the file comes from the Cargo.lock file under the `system-deps`
-	# dependency segment. This fake checksum file needs to be updated after each
-	# adsys update.
+	# Some crates are shipped with .a files, which get removed by the helpers during the package build as a safety measure.
+	# This results in cargo failing to compile, since the files (which are listed in the checksums) are not there anymore.
+	# For those crates, we need to replace their checksum with a more general one that only lists the crate checksum, instead of each file.
 	if [ ! -d $(CARGO_VENDOR_DIR)/ ]; then \
 		$(CARGO) vendor $(CARGO_VENDOR_DIR); \
-		cp debian/cargo-checksum.json $(CARGO_VENDOR_DIR)/system-deps/.cargo-checksum.json; \
 		[ ! -e $(DH_CARGO_VENDORED_SOURCES) ] || $(DH_CARGO_VENDORED_SOURCES); \
+		\
+		[ -e /usr/bin/jq ] || (echo "jq is required to run this script. Try installing it with 'sudo apt install jq'" && exit 1); \
+		\
+		for dep in $$(ls vendor_rust -1); do \
+			checksum_file="vendor_rust/$${dep}/.cargo-checksum.json"; \
+			a_files=$$(cat $${checksum_file} | jq '.files | keys | map(select(.|test(".a$$")))'); \
+			if [ "$$a_files" = "[]" ]; then \
+				continue; \
+			fi; \
+			pkg_checksum=$$(cat "$${checksum_file}" | jq '.package'); \
+			echo "{\"files\": {}, \"package\": $${pkg_checksum}}" >"$${checksum_file}"; \
+		done; \
 	fi
 	# That last line above is to warn whoever's doing the packaging that they
 	# need to update the Vendored-Sources field. The initial packaging work


### PR DESCRIPTION
Our previous strategy of copying a fake checksum file to the problematic crate was unsustainable, since dependencies can change (either directly or indirectly) when updating our code (or our dependencies version) and new crates with .a files could emerge.
To avoid such problems in the future, the idea is to simplify the checksums when building the source package. This way, we can still use the general crate checksum while also being able to build the package without the .a files.