### PR TITLE
Changing covermode to set in qa.yaml

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -96,15 +96,14 @@ jobs:
         run: |
           set -eu
 
-          go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=count ./...
+          go test -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=set ./...
 
           # Run integration tests that need sudo
           # Use command substitution to preserve go binary path (sudo does not preserve path even with -E)
-          sudo -E $(which go) test -coverpkg=./... -coverprofile=/tmp/coverage.sudo.out -covermode=count $SUDO_PACKAGES
+          sudo -E $(which go) test -coverpkg=./... -coverprofile=/tmp/coverage.sudo.out -covermode=set $SUDO_PACKAGES
 
           # Combine coverage files, and filter out test utilities and generated files
-          echo "mode: set" > /tmp/coverage.combined.out
-          grep -hv -e "mode: set" -e "testutils" -e "pb.go:" /tmp/coverage.out /tmp/coverage.sudo.out > /tmp/coverage.combined.out
+          grep -hv -e "testutils" -e "pb.go:" /tmp/coverage.out /tmp/coverage.sudo.out > /tmp/coverage.combined.out
       - name: Run tests (with race detector)
         run: |
           go test -race ./...


### PR DESCRIPTION
We were using `covermode=count` in `adsys`, which isn't what we really want. This PR changes the `covermode` to `set`, which basically translates to `true` or `false` if the line is covered or not. Could help with #509.

DEENG-639