### PR TITLE
Avoid translating unneeded strings

### DIFF
--- a/cmd/adsysd/client/version.go
+++ b/cmd/adsysd/client/version.go
@@ -24,7 +24,7 @@ func (a *App) installVersion() {
 
 // getVersion returns the current server and client versions.
 func (a App) getVersion() (err error) {
-	fmt.Printf(i18n.G("%s\t%s")+"\n", CmdName, consts.Version)
+	fmt.Printf("%s\t%s"+"\n", CmdName, consts.Version)
 
 	client, err := adsysservice.NewClient(a.config.Socket, a.getTimeout())
 	if err != nil {
@@ -41,7 +41,7 @@ func (a App) getVersion() (err error) {
 	if err != nil {
 		return err
 	}
-	fmt.Printf(i18n.G("%s\t\t%s")+"\n", "adsysd", version)
+	fmt.Printf("%s\t\t%s"+"\n", "adsysd", version)
 
 	return nil
 }

--- a/cmd/adsysd/daemon/version.go
+++ b/cmd/adsysd/daemon/version.go
@@ -20,6 +20,6 @@ func (a *App) installVersion() {
 
 // getVersion returns the current service version.
 func getVersion() (err error) {
-	fmt.Printf(i18n.G("%s\t%s")+"\n", CmdName, consts.Version)
+	fmt.Printf("%s\t%s"+"\n", CmdName, consts.Version)
 	return nil
 }

--- a/cmd/adwatchd/commands/version.go
+++ b/cmd/adwatchd/commands/version.go
@@ -21,6 +21,6 @@ func (a *App) installVersion() {
 
 // getVersion returns the current service version.
 func getVersion() (err error) {
-	fmt.Printf(i18n.G("%s\t%s")+"\n", watchdconfig.CmdName, consts.Version)
+	fmt.Printf("%s\t%s"+"\n", watchdconfig.CmdName, consts.Version)
 	return nil
 }

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -437,7 +437,7 @@ func (ad *AD) parseGPOs(ctx context.Context, gpos []gpo, objectClass ObjectClass
 			// Decode and apply policies in gpo order. First win
 			pols, err := registry.DecodePolicy(f)
 			if err != nil {
-				return fmt.Errorf(i18n.G("%s: %v"), f.Name(), err)
+				return fmt.Errorf("%s: %w", f.Name(), err)
 			}
 
 			// filter keys to be overridden
@@ -449,7 +449,7 @@ func (ad *AD) parseGPOs(ctx context.Context, gpos []gpo, objectClass ObjectClass
 					continue
 				}
 				if pol.Err != nil {
-					return fmt.Errorf(i18n.G("%s: %v"), f.Name(), pol.Err)
+					return fmt.Errorf("%s: %w", f.Name(), pol.Err)
 				}
 				pol.Key = strings.TrimPrefix(pol.Key, keyFilterPrefix)
 

--- a/internal/cmdhandler/suggest.go
+++ b/internal/cmdhandler/suggest.go
@@ -50,12 +50,12 @@ func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error
 	if len(suggestions) > 0 {
 		suggestionsMsg += i18n.G("Did you mean this?\n")
 		for _, s := range suggestions {
-			suggestionsMsg += fmt.Sprintf(i18n.G("\t%v\n"), s)
+			suggestionsMsg += fmt.Sprintf("\t%v\n", s)
 		}
 	}
 
 	if suggestionsMsg != "" {
-		requireMsg = fmt.Sprintf(i18n.G("%s. %s"), requireMsg, suggestionsMsg)
+		requireMsg = fmt.Sprintf("%s. %s", requireMsg, suggestionsMsg)
 	}
 
 	return fmt.Errorf(requireMsg, cmd.Name())

--- a/internal/watchdservice/watchdservice.go
+++ b/internal/watchdservice/watchdservice.go
@@ -289,7 +289,7 @@ func (s *WatchdService) Status(ctx context.Context) (status string, err error) {
 	}
 
 	for _, dir := range svcInfo.dirs {
-		statStr.WriteString(fmt.Sprintf(i18n.G("\n  - %s"), dir))
+		statStr.WriteString(fmt.Sprintf("\n  - %s", dir))
 	}
 
 	if pathMismatch {


### PR DESCRIPTION
There's no point in marking strings that are comprised of only interpolations with i18n.G, as there's nothing to actually translate.