### PR TITLE
Warn when Pro-only rules are configured

### DIFF
--- a/cmd/adsysd/integration_tests/testdata/TestServiceStatus/golden/ubuntu_pro_subscription_is_not_active
+++ b/cmd/adsysd/integration_tests/testdata/TestServiceStatus/golden/ubuntu_pro_subscription_is_not_active
@@ -4,7 +4,12 @@ Connected users:
   user2@example.com, updated on DDD MON D HH:MM
 Next Refresh: Tue May 25 14:55
 
-Ubuntu Pro subscription is not active on this machine. Some policies won't be applied.
+Ubuntu Pro subscription is not active on this machine. Rules belonging to the following policy types will not be applied:
+  - apparmor
+  - mount
+  - privilege
+  - proxy
+  - scripts
 
 Active Directory:
   Current backend is SSSD

--- a/internal/adsysservice/service.go
+++ b/internal/adsysservice/service.go
@@ -13,8 +13,10 @@ import (
 	"github.com/ubuntu/adsys/internal/consts"
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
+	"github.com/ubuntu/adsys/internal/policies"
 	"github.com/ubuntu/adsys/internal/stdforward"
 	"github.com/ubuntu/decorate"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 )
 
@@ -124,7 +126,11 @@ func (s *Service) Status(_ *adsys.Empty, stream adsys.Service_StatusServer) (err
 		}
 	}
 
-	ubuntuProStatus := i18n.G("Ubuntu Pro subscription is not active on this machine. Some policies won't be applied.")
+	ubuntuProStatus := i18n.G("Ubuntu Pro subscription is not active on this machine. Rules belonging to the following policy types will not be applied:\n")
+	proOnlyRules := slices.Clone(policies.ProOnlyRules)
+	slices.Sort(proOnlyRules)
+	ubuntuProStatus = ubuntuProStatus + "  - " + strings.Join(proOnlyRules, "\n  - ")
+
 	subscriptionEnabled := s.policyManager.GetSubscriptionState(stream.Context())
 	if subscriptionEnabled {
 		ubuntuProStatus = i18n.G("Ubuntu Pro subscription active.")

--- a/internal/policies/export_test.go
+++ b/internal/policies/export_test.go
@@ -9,8 +9,6 @@ const (
 	PoliciesFileName       = policiesFileName
 )
 
-var ProOnlyRules = proOnlyRules
-
 // WithGDM specifies a personalized gdm manager.
 func WithGDM(m *gdm.Manager) Option {
 	return func(o *options) error {

--- a/internal/policies/manager.go
+++ b/internal/policies/manager.go
@@ -49,9 +49,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// proOnlyRules are the rules that are only available for Pro subscribers. They
+// ProOnlyRules are the rules that are only available for Pro subscribers. They
 // will be filtered otherwise.
-var proOnlyRules = []string{"privilege", "scripts", "mount", "apparmor", "proxy"}
+var ProOnlyRules = []string{"privilege", "scripts", "mount", "apparmor", "proxy"}
 
 // Manager handles all managers for various policy handlers.
 type Manager struct {
@@ -415,7 +415,7 @@ func filterRules(ctx context.Context, rules map[string][]entry.Entry) []string {
 
 	var filteredRules []string
 	for rule := range rules {
-		if !slices.Contains(proOnlyRules, rule) {
+		if !slices.Contains(ProOnlyRules, rule) {
 			continue
 		}
 		filteredRules = append(filteredRules, rule)


### PR DESCRIPTION
If the user has configured rules that are only eligible to Ubuntu Pro subscribers, issue a warning in addition to filtering them out.

I've opted for this approach instead of listing the types in the `applied` command output as the latter can change if the machine is unenrolled from Pro after applying the Pro-only rules for example.

Additionally, as a user (and developer) I'd expect to be warned as early as possible of any of my set rules not being applied, namely during the execution of the `update` command. I've experienced this numerous times when adding new managers and forgetting to remove the filtering for them.

Fixes #422 / DEENG-481