### PR TITLE
Updating sync strategies for the policy managers

### DIFF
--- a/internal/policies/gdm/gdm.go
+++ b/internal/policies/gdm/gdm.go
@@ -8,7 +8,6 @@ package gdm
 import (
 	"context"
 	"strings"
-	"sync"
 
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
 	"github.com/ubuntu/adsys/internal/i18n"
@@ -20,7 +19,6 @@ import (
 
 // Manager prevents running multiple gdm update process in parallel while parsing policy in ApplyPolicy.
 type Manager struct {
-	mu    sync.RWMutex
 	dconf *dconf.Manager
 }
 
@@ -60,8 +58,6 @@ func New(opts ...option) (m *Manager, err error) {
 // ApplyPolicy generates a dconf computer or user policy based on a list of entries.
 func (m *Manager) ApplyPolicy(ctx context.Context, entries []entry.Entry) (err error) {
 	defer decorate.OnError(&err, i18n.G("can't apply gdm policy"))
-
-	m.mu.RLock()
 
 	log.Debug(ctx, "ApplyPolicy gdm policy")
 

--- a/internal/policies/privilege/privilege.go
+++ b/internal/policies/privilege/privilege.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/ubuntu/adsys/internal/consts"
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
@@ -53,8 +52,6 @@ const adsysBaseConfName = "99-adsys-privilege-enforcement"
 
 // Manager prevents running multiple privilege update process in parallel while parsing policy in ApplyPolicy.
 type Manager struct {
-	privilegeMu sync.Mutex
-
 	sudoersDir   string
 	policyKitDir string
 }
@@ -86,9 +83,6 @@ func (m *Manager) ApplyPolicy(ctx context.Context, objectName string, isComputer
 	}
 	sudoersConf := filepath.Join(sudoersDir, adsysBaseConfName)
 	policyKitConf := filepath.Join(policyKitDir, "localauthority.conf.d", adsysBaseConfName+".conf")
-
-	m.privilegeMu.Lock()
-	defer m.privilegeMu.Unlock()
 
 	log.Debugf(ctx, "Applying privilege policy to %s", objectName)
 

--- a/internal/policies/proxy/proxy.go
+++ b/internal/policies/proxy/proxy.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
 
 	"github.com/godbus/dbus/v5"
 	log "github.com/ubuntu/adsys/internal/grpc/logstreamer"
@@ -39,7 +38,6 @@ const errDBusServiceUnknownName = "org.freedesktop.DBus.Error.ServiceUnknown"
 
 // Manager prevents running multiple apparmor update processes in parallel while parsing policy in ApplyPolicy.
 type Manager struct {
-	mu           sync.Mutex
 	proxyApplier Caller
 }
 
@@ -89,9 +87,6 @@ func (m *Manager) ApplyPolicy(ctx context.Context, objectName string, isComputer
 	if len(entries) == 0 {
 		return nil
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	args := make(map[string]string)
 	for _, e := range entries {


### PR DESCRIPTION
Added a mutex map to the One Manager to sync the applying process of the multiple policy managers. We don't want to run multiple policy managers concurrently for the same object, so if we start applying a policy to the object, the other managers should wait for it to finish before starting their applying process to that object.

Closes #427 / DEENG-644