### PR TITLE
Print logs when downloadables are up to date

### DIFF
--- a/internal/ad/download.go
+++ b/internal/ad/download.go
@@ -133,6 +133,12 @@ func (ad *AD) fetch(ctx context.Context, krb5Ticket string, downloadables map[st
 			}
 
 			if !shouldDownload {
+				if g.isAssets {
+					log.Infof(ctx, i18n.G("Assets directory is already up to date"))
+				} else {
+					log.Infof(ctx, i18n.G("GPO %q is already up to date"), g.name)
+				}
+
 				return nil
 			}
 
@@ -187,6 +193,7 @@ func needsDownload(ctx context.Context, client *libsmbclient.Client, g *download
 		return false, err
 	}
 
+	log.Debugf(ctx, "Local version for %q: %d, remote version: %d", g.name, localVersion, remoteVersion)
 	if localVersion >= remoteVersion {
 		return false, nil
 	}


### PR DESCRIPTION
We print logs when downloading GPOs/assets but not when they are already up to date. Handle this, and also add a debug print that lists the local and remote versions of the GPT.INI files.

Fixes #454 / DEENG-504