### PR TITLE
Adding clang-format configuration and applying the linter to C source files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# Configures clang-format for the project.
+# Options can be consulted on https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+Language: Cpp # Clang format will only be applied to C/C++ files.
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+UseTab: Never

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -17,12 +17,11 @@ jobs:
   quality:
     name: Code quality and mod files up to date
     runs-on: ubuntu-latest
-    container: ubuntu:latest
     steps:
       - name: Install dependencies
         run: |
-          DEBIAN_FRONTEND=noninteractive apt update
-          DEBIAN_FRONTEND=noninteractive apt install -y ${{ env.apt_dependencies }}
+          sudo DEBIAN_FRONTEND=noninteractive apt update
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y ${{ env.apt_dependencies }}
       - name: work around permission issue with git vulnerability (we are local here). TO REMOVE
         run: git config --global --add safe.directory /__w/adsys/adsys
       - uses: actions/checkout@v3
@@ -52,6 +51,12 @@ jobs:
         if: ${{ always() }}
       - name: Building
         run: go build ./...
+        if: ${{ always() }}
+      - name: C code formatting
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          include-regex: '^.*\.(c|h)$' # Makes sure to run only on C (source and header) files
+          exclude-regex: 'vendor' # Excludes the vendor directory
         if: ${{ always() }}
 
   tests:

--- a/internal/ad/backends/winbind/mock/libwbclient_mock.c
+++ b/internal/ad/backends/winbind/mock/libwbclient_mock.c
@@ -1,13 +1,11 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdio.h>
-
 #include <wbclient.h>
 
-char *get_mock_behavior()
-{
+char *get_mock_behavior() {
     char *behavior = getenv("ADSYS_WBCLIENT_BEHAVIOR");
     if (behavior == NULL) {
         printf("ADSYS_WBCLIENT_BEHAVIOR not set, exiting...");
@@ -16,8 +14,7 @@ char *get_mock_behavior()
     return behavior;
 }
 
-wbcErr wbcLookupDomainController(const char *domain, uint32_t flags, struct wbcDomainControllerInfo **dc_info)
-{
+wbcErr wbcLookupDomainController(const char *domain, uint32_t flags, struct wbcDomainControllerInfo **dc_info) {
     char *behavior = get_mock_behavior();
     if (strcmp(behavior, "error_getting_dc_name") == 0) {
         return WBC_ERR_UNKNOWN_FAILURE;
@@ -30,8 +27,7 @@ wbcErr wbcLookupDomainController(const char *domain, uint32_t flags, struct wbcD
     return WBC_ERR_SUCCESS;
 }
 
-wbcErr wbcInterfaceDetails(struct wbcInterfaceDetails **details)
-{
+wbcErr wbcInterfaceDetails(struct wbcInterfaceDetails **details) {
     char *behavior = get_mock_behavior();
     if (strcmp(behavior, "domain_not_found") == 0) {
         return WBC_ERR_DOMAIN_NOT_FOUND;
@@ -44,8 +40,7 @@ wbcErr wbcInterfaceDetails(struct wbcInterfaceDetails **details)
     return WBC_ERR_SUCCESS;
 }
 
-wbcErr wbcDomainInfo(const char *domain, struct wbcDomainInfo **dinfo)
-{
+wbcErr wbcDomainInfo(const char *domain, struct wbcDomainInfo **dinfo) {
     char *behavior = get_mock_behavior();
     if (strcmp(behavior, "error_getting_online_status") == 0) {
         return WBC_ERR_UNKNOWN_FAILURE;


### PR DESCRIPTION
As discussed, we decided to add a linter to C source files in our projects.
This PR adds a .clang-format file to the root directory and applies the linter to our C files.