### PR TITLE
Address a few issues in smbsafe_test.go

### DIFF
--- a/internal/smbsafe/smbsafe_test.go
+++ b/internal/smbsafe/smbsafe_test.go
@@ -126,11 +126,11 @@ func TestMultipleSmbLocksOnlyReleaseOnLast(t *testing.T) {
 func shouldHaveWaited(t *testing.T, startpoint time.Time) {
 	t.Helper()
 
-	require.Less(t, int64(waitTime), int64(time.Since(startpoint)), "Should have waited")
+	require.Less(t, uint64(waitTime-time.Millisecond), uint64(time.Since(startpoint)), "Should have waited")
 }
 
 func shouldNotHaveWaited(t *testing.T, startpoint time.Time) {
 	t.Helper()
 
-	require.Less(t, int64(time.Since(startpoint)), int64(waitTime), "Shouldn’t have waited")
+	require.Less(t, uint64(time.Since(startpoint)), uint64(waitTime+time.Millisecond), "Shouldn’t have waited")
 }


### PR DESCRIPTION
- Increase sleep time to be a little more than the time we expect the routine to wait to prevent some time mismatches.
- Change type conversion to uint64 rather than int64 to avoid overflows.