### PR TITLE
Fix typo on build command for the admxgen package

### DIFF
--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: go.mod
       - run: |
           mkdir /tmp/adsys
-          CO_ENABLED=0 go build ./cmd/admxgen/
+          CGO_ENABLED=0 go build ./cmd/admxgen/
       - name: Upload admxgen
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
There was a typo in the build command for the admx package, which was resulting in the package not building with CGo disabled and thus causing problems when generating adm* files for different distros.