### PR TITLE
Update policy definitions to include dconf key for dark mode background

### DIFF
--- a/cmd/admxgen/defs/categories.yaml
+++ b/cmd/admxgen/defs/categories.yaml
@@ -21,6 +21,7 @@ categories:
         defaultpolicyclass: "User"
         policies:
           - "/org/gnome/desktop/background/picture-uri"
+          - "/org/gnome/desktop/background/picture-uri-dark"
           - "/org/gnome/desktop/background/picture-options"
       - displayname: "Shell"
         defaultpolicyclass: "User"

--- a/cmd/admxgen/defs/dconf.yaml
+++ b/cmd/admxgen/defs/dconf.yaml
@@ -3,6 +3,7 @@
 - objectpath: "/org/gnome/desktop/a11y/applications/screen-magnifier-enabled"
 - objectpath: "/org/gnome/desktop/a11y/applications/screen-reader-enabled"
 - objectpath: "/org/gnome/desktop/background/picture-uri"
+- objectpath: "/org/gnome/desktop/background/picture-uri-dark"
 - objectpath: "/org/gnome/desktop/background/picture-options"
 - objectpath: "/org/gnome/shell/favorite-apps"
 - objectpath: "/org/gnome/desktop/background/show-desktop-icons"

--- a/policies/Ubuntu/all/Ubuntu.adml
+++ b/policies/Ubuntu/all/Ubuntu.adml
@@ -106,6 +106,20 @@ Supported on Ubuntu 20.04, 22.04, 22.10, 23.04, 23.10.</string>
       <string id="UbuntuDisplayUser2210DconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
       <string id="UbuntuDisplayUser2204DconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
       <string id="UbuntuDisplayUser2004DconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
+      <string id="UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureUriDark">URI to use for the background image. Note that the backend only supports local (file://) URIs.
+
+- Type: dconf
+- Key: /org/gnome/desktop/background/picture-uri-dark
+- Default: &#39;file:///usr/share/backgrounds/warty-final-ubuntu.png&#39;
+
+Note: default system value is used for &#34;Not Configured&#34; and enforced if &#34;Disabled&#34;.
+
+Supported on Ubuntu 22.04, 22.10, 23.04, 23.10.</string>
+      <string id="UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
+      <string id="UbuntuDisplayUser2310DconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
+      <string id="UbuntuDisplayUser2304DconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
+      <string id="UbuntuDisplayUser2210DconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
+      <string id="UbuntuDisplayUser2204DconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
       <string id="UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureOptions">Determines how the image set by wallpaper_filename is rendered. Possible values are “none”, “wallpaper”, “centered”, “scaled”, “stretched”, “zoom”, “spanned”.
 
 - Type: dconf
@@ -1848,6 +1862,36 @@ An Ubuntu Pro subscription on the client is required to apply this policy.</stri
         <text/>
         <checkBox refId="UbuntuOverrideElemUser2004DconfOrgGnomeDesktopBackgroundPictureUri" defaultChecked="false">Override value for 20.04:</checkBox>
         <textBox refId="UbuntuElemUser2004DconfOrgGnomeDesktopBackgroundPictureUri">
+          <label></label>
+          <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
+        </textBox>
+      </presentation>
+      <presentation id="UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureUriDark">
+        <textBox refId="UbuntuElemUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark">
+          <label>Picture URI (dark)</label>
+          <defaultValue></defaultValue>
+        </textBox>
+        <text/>
+        <checkBox refId="UbuntuOverrideElemUser2310DconfOrgGnomeDesktopBackgroundPictureUriDark" defaultChecked="false">Override value for 23.10:</checkBox>
+        <textBox refId="UbuntuElemUser2310DconfOrgGnomeDesktopBackgroundPictureUriDark">
+          <label></label>
+          <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
+        </textBox>
+        <text/>
+        <checkBox refId="UbuntuOverrideElemUser2304DconfOrgGnomeDesktopBackgroundPictureUriDark" defaultChecked="false">Override value for 23.04:</checkBox>
+        <textBox refId="UbuntuElemUser2304DconfOrgGnomeDesktopBackgroundPictureUriDark">
+          <label></label>
+          <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
+        </textBox>
+        <text/>
+        <checkBox refId="UbuntuOverrideElemUser2210DconfOrgGnomeDesktopBackgroundPictureUriDark" defaultChecked="false">Override value for 22.10:</checkBox>
+        <textBox refId="UbuntuElemUser2210DconfOrgGnomeDesktopBackgroundPictureUriDark">
+          <label></label>
+          <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
+        </textBox>
+        <text/>
+        <checkBox refId="UbuntuOverrideElemUser2204DconfOrgGnomeDesktopBackgroundPictureUriDark" defaultChecked="false">Override value for 22.04:</checkBox>
+        <textBox refId="UbuntuElemUser2204DconfOrgGnomeDesktopBackgroundPictureUriDark">
           <label></label>
           <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
         </textBox>

--- a/policies/Ubuntu/all/Ubuntu.admx
+++ b/policies/Ubuntu/all/Ubuntu.admx
@@ -328,6 +328,35 @@
         <text id="UbuntuElemUser2004DconfOrgGnomeDesktopBackgroundPictureUri" valueName="20.04" />
       </elements>
     </policy>
+    <policy name="UbuntuUserDconfOrgGnomeDesktopBackgroundPictureUriDark" class="User" displayName="$(string.UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark)" explainText="$(string.UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureUriDark)" presentation="$(presentation.UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureUriDark)" key="Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri-dark" valueName="metaValues">
+      <parentCategory ref="UbuntuBackground" />
+      <supportedOn ref="Ubuntu" />
+      <enabledValue><string>{"22.04":{"empty":"''","meta":"s"},"22.10":{"empty":"''","meta":"s"},"23.04":{"empty":"''","meta":"s"},"23.10":{"empty":"''","meta":"s"},"all":{"empty":"''","meta":"s"}}</string></enabledValue>
+      <disabledValue><string>{"22.04":{"meta":"s"},"22.10":{"meta":"s"},"23.04":{"meta":"s"},"23.10":{"meta":"s"},"all":{"meta":"s"}}</string></disabledValue>
+      <elements>
+        <text id="UbuntuElemUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="all" />
+        <boolean id="UbuntuOverrideElemUser2310DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="Override23.10">
+          <trueValue><string>true</string></trueValue>
+          <falseValue><string>false</string></falseValue>
+        </boolean>
+        <text id="UbuntuElemUser2310DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="23.10" />
+        <boolean id="UbuntuOverrideElemUser2304DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="Override23.04">
+          <trueValue><string>true</string></trueValue>
+          <falseValue><string>false</string></falseValue>
+        </boolean>
+        <text id="UbuntuElemUser2304DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="23.04" />
+        <boolean id="UbuntuOverrideElemUser2210DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="Override22.10">
+          <trueValue><string>true</string></trueValue>
+          <falseValue><string>false</string></falseValue>
+        </boolean>
+        <text id="UbuntuElemUser2210DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="22.10" />
+        <boolean id="UbuntuOverrideElemUser2204DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="Override22.04">
+          <trueValue><string>true</string></trueValue>
+          <falseValue><string>false</string></falseValue>
+        </boolean>
+        <text id="UbuntuElemUser2204DconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="22.04" />
+      </elements>
+    </policy>
     <policy name="UbuntuUserDconfOrgGnomeDesktopBackgroundPictureOptions" class="User" displayName="$(string.UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureOptions)" explainText="$(string.UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureOptions)" presentation="$(presentation.UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureOptions)" key="Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-options" valueName="metaValues">
       <parentCategory ref="UbuntuBackground" />
       <supportedOn ref="Ubuntu" />

--- a/policies/Ubuntu/lts-only/Ubuntu.adml
+++ b/policies/Ubuntu/lts-only/Ubuntu.adml
@@ -91,6 +91,16 @@ Supported on Ubuntu 20.04, 22.04.</string>
       <string id="UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
       <string id="UbuntuDisplayUser2204DconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
       <string id="UbuntuDisplayUser2004DconfOrgGnomeDesktopBackgroundPictureUri">Picture URI</string>
+      <string id="UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureUriDark">URI to use for the background image. Note that the backend only supports local (file://) URIs.
+
+- Type: dconf
+- Key: /org/gnome/desktop/background/picture-uri-dark
+- Default: &#39;file:///usr/share/backgrounds/warty-final-ubuntu.png&#39;
+
+Note: default system value is used for &#34;Not Configured&#34; and enforced if &#34;Disabled&#34;.
+
+Supported on Ubuntu 22.04.</string>
+      <string id="UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark">Picture URI (dark)</string>
       <string id="UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureOptions">Determines how the image set by wallpaper_filename is rendered. Possible values are “none”, “wallpaper”, “centered”, “scaled”, “stretched”, “zoom”, “spanned”.
 
 - Type: dconf
@@ -1380,6 +1390,12 @@ An Ubuntu Pro subscription on the client is required to apply this policy.</stri
         <textBox refId="UbuntuElemUser2004DconfOrgGnomeDesktopBackgroundPictureUri">
           <label></label>
           <defaultValue>'file:///usr/share/backgrounds/warty-final-ubuntu.png'</defaultValue>
+        </textBox>
+      </presentation>
+      <presentation id="UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureUriDark">
+        <textBox refId="UbuntuElemUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark">
+          <label>Picture URI (dark)</label>
+          <defaultValue></defaultValue>
         </textBox>
       </presentation>
       <presentation id="UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureOptions">

--- a/policies/Ubuntu/lts-only/Ubuntu.admx
+++ b/policies/Ubuntu/lts-only/Ubuntu.admx
@@ -217,6 +217,15 @@
         <text id="UbuntuElemUser2004DconfOrgGnomeDesktopBackgroundPictureUri" valueName="20.04" />
       </elements>
     </policy>
+    <policy name="UbuntuUserDconfOrgGnomeDesktopBackgroundPictureUriDark" class="User" displayName="$(string.UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark)" explainText="$(string.UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureUriDark)" presentation="$(presentation.UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureUriDark)" key="Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri-dark" valueName="metaValues">
+      <parentCategory ref="UbuntuBackground" />
+      <supportedOn ref="Ubuntu" />
+      <enabledValue><string>{"22.04":{"empty":"''","meta":"s"},"all":{"empty":"''","meta":"s"}}</string></enabledValue>
+      <disabledValue><string>{"22.04":{"meta":"s"},"all":{"meta":"s"}}</string></disabledValue>
+      <elements>
+        <text id="UbuntuElemUserAllDconfOrgGnomeDesktopBackgroundPictureUriDark" valueName="all" />
+      </elements>
+    </policy>
     <policy name="UbuntuUserDconfOrgGnomeDesktopBackgroundPictureOptions" class="User" displayName="$(string.UbuntuDisplayUserAllDconfOrgGnomeDesktopBackgroundPictureOptions)" explainText="$(string.UbuntuExplainTextUserDconfOrgGnomeDesktopBackgroundPictureOptions)" presentation="$(presentation.UbuntuPresentationUserDconfOrgGnomeDesktopBackgroundPictureOptions)" key="Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-options" valueName="metaValues">
       <parentCategory ref="UbuntuBackground" />
       <supportedOn ref="Ubuntu" />


### PR DESCRIPTION
Adds policy to also configure the background picture for the dark mode, which uses a different key: picture-uri-dark.

Closes #701 / UDENG-340

