### PR TITLE
Open issue when ADMX/L builds fail

### DIFF
--- a/.github/workflows/adm-builds-fail.md
+++ b/.github/workflows/adm-builds-fail.md
@@ -1,0 +1,5 @@
+---
+title: ADMX/L build failed
+labels: bug, jira
+---
+Failed to build ADMX/L files for adsys. Please take a look at the run output in {{ env.RUN_URL }}.

--- a/.github/workflows/adm-builds.yaml
+++ b/.github/workflows/adm-builds.yaml
@@ -196,3 +196,20 @@ jobs:
           branch: auto-update-policydefinitions-${{ steps.get-branch-name.outputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-branch: true
+
+  open-issue-on-fail:
+    name: Open issue on failure
+    runs-on: ubuntu-latest
+    needs: integrate-ad
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create issue if build failed
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/workflows/adm-builds-fail.md
+          search_existing: open
+          update_existing: true


### PR DESCRIPTION
ADMX/L build failures are sometimes hard to spot and this isn't great. Opening an issue and syncing it to Jira will help us to notice those failures and to start handling them.

Example of issue opened by the action: #756. (It was opened before fixing the job order and without the Jira tag to avoid cluttering Jira with test issues)

UDENG-990