### PR TITLE
Add prompt sign to sh-session code blocks

### DIFF
--- a/doc/11.-Certificate-autoenrollment.md
+++ b/doc/11.-Certificate-autoenrollment.md
@@ -123,7 +123,8 @@ Resubmitting "galacticcafe-CA.Machine" to "galacticcafe-CA".
 Request "galacticcafe-CA.Machine" removed.
 
 # Remove CA
-getcert remove-ca -c galacticcafe-CA
+> getcert remove-ca -c galacticcafe-CA
+CA "galacticcafe-CA" removed.
 ```
 
 Note that tampering with certificate data outside of ADSys (e.g. manually unmonitoring using `getcert`) will render the GPO cache obsolete as it will cause a drift between the actual state and the "known" cached state. In this case, it's best to remove the cache file at `/var/lib/adsys/samba/*.tdb` together with any enrolled certificates and CAs to ensure a clean slate.
@@ -145,7 +146,7 @@ export KRB5CCNAME=/var/run/adsys/krb5cc/$(hostname)
 Then, run the script passing the required arguments (the argument list is also printed in the ADSys debug logs during policy application):
 ```sh-session
 # Un-enroll machine
-./cert-autoenroll unenroll keypress galacticcafe.com --state_dir /var/lib/adsys --debug
+> ./cert-autoenroll unenroll keypress galacticcafe.com --state_dir /var/lib/adsys --debug
 ```
 
 ### Errors communicating with the CEP/CES servers


### PR DESCRIPTION
Missed this in the original PR. Thanks didrocks for spotting.