### PR TITLE
build: Use go 1.21.1 to avoid security vulnerability

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
                dh-apport,
                dh-golang,
-               golang-go (>= 2:1.20~),
+               golang-go (>= 2:1.21.1~),
                libsmbclient-dev,
                libdbus-1-dev,
                libglib2.0-dev,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/adsys
 
-go 1.20
+go 1.21.1
 
 require (
 	github.com/charmbracelet/bubbles v0.16.1


### PR DESCRIPTION
Ensure we are using the safe Go version as we are using parsing (even if we only do this in documentation generation).
Update packaging too.