### PR TITLE
ci: Remove scopes from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      include: "scope"
       prefix: "deps(go)"
 
   - package-ecosystem: "gomod"
@@ -16,7 +15,6 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      include: "scope"
       prefix: "deps(go-tools)"
 
   - package-ecosystem: "github-actions"
@@ -26,5 +24,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      include: "scope"
       prefix: "deps(ci)"


### PR DESCRIPTION
Having the scopes defined in the commit message was adding a "(deps)" tag to it, but that's exactly the purpose of the prefixes that we already add.