### PR TITLE
fix(docs): Retries link checker on failure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,9 @@ linkcheck_anchors_ignore_for_url = [
     r'https://github\.com/.*'
 ]
 
+# Some Ubuntu links are unstable
+linkcheck_retries = 10
+
 ############################################################
 ### Styling
 ############################################################


### PR DESCRIPTION
Some Ubuntu websites are unstable so retry up to 3 times.