### PR TITLE
docs: added tutorial section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ ADSys is valuable for system administrators who wish to manage Ubuntu Desktop cl
 
 ```{toctree}
 :hidden:
+tutorial/index
 how-to/index
 reference/index
 explanation/index
@@ -20,22 +21,26 @@ explanation/index
 ````{grid} 1 1 2 2
 
 ```{grid-item}
+### [Tutorials](tutorial/index)
+
+**Start here**: a hands-on introduction to ADSys for new users
+```
+
+```{grid-item}
 ### [How-to guides](how-to/index)
 
 **Step-by-step guides** covering key operations and common tasks
 ```
+
+````
+
+````{grid} 1 1 2 2
 
 ```{grid-item}
 ### [Explanation](explanation/index)
 
 **Discussion and clarification** of key topics
 ```
-
-
-````
-
-````{grid} 1 1 2 2
-
 
 ```{grid-item}
 ### [Reference](reference/index)

--- a/docs/tutorial/certificates-autoenrollment.md
+++ b/docs/tutorial/certificates-autoenrollment.md
@@ -1,0 +1,5 @@
+# Certificates Auto-Enrollment
+
+[Certificate Auto-Enrollment](/explanation/certificates.md) is a key component of Ubuntu's Active Directory GPO support. This feature enables clients to seamlessly enroll for certificates from Active Directory Certificate Services. In this demonstration, we'll guide you through the entire process, starting from the initial setup requirements to configuring the Active Directory policy. This demonstration is designed to provide you with a hands-on understanding of how to efficiently implement and manage certificate auto-enrollment, ensuring your systems remain secure and compliant with organizational policies.
+
+[![Demo video](https://img.youtube.com/vi/RwVU7v0sEVY/hqdefault.jpg)](https://www.youtube.com/embed/RwVU7v0sEVY)

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,14 @@
+# Tutorials
+
+This section contains step-by-step tutorials to help you get started with ADSys. We hope our tutorials make as few assumptions as possible and are accessible to anyone with an interest in ADSys. They should be a great place to start learning about ADSys, how it works, and what it’s capable of.
+
+```{toctree}
+:hidden:
+certificates-autoenrollment
+```
+
+## Certificates Auto-Enrollment
+
+Explore the essentials of Ubuntu's Certificate Auto-Enrollment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
+
+* [Certificates auto-enrollment demo](certificates-autoenrollment.md)


### PR DESCRIPTION
Added the section as part of the main index.
There is an initial tutorial which is actually a demo of certificates auto-enrollment.

UDENG-1787