### PR TITLE
maint: remove redundant line from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ installer/Output
 
 # Packaging artefacts
 debian/*debhelper*
-debian/debhelper-build-stamp
 debian/files
 debian/*.substvars
 debian/tmp


### PR DESCRIPTION
This was already handled by the line above.