### PR TITLE
maint: bump go toolchain to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ubuntu/adsys
 
-go 1.21.4
+go 1.21.0
+
+toolchain go1.21.5
 
 require (
 	github.com/charmbracelet/bubbles v0.16.1


### PR DESCRIPTION
Set to toolchain to 1.21.5 to avoid some vulnerabilities in our code path.

Downgrade the go mod version itself as in term of language, we are compatible with it and there is no bug fixes requiring a newer version. The desired toolchain can still be overriden if desired, but it helps knowing our requirements for fixing those vulnerabilitie issues.

Same approach as https://github.com/ubuntu/authd/pull/134