### PR TITLE
fix(test): Fix require outside of main goroutine

### DIFF
--- a/cmd/adsysd/daemon/daemon_test.go
+++ b/cmd/adsysd/daemon/daemon_test.go
@@ -307,16 +307,16 @@ func startDaemon(t *testing.T, setupEnv bool, args ...string) (app *daemon.App, 
 	a := daemon.New()
 	a.SetArgs(args...)
 
-	ch := make(chan error)
+	errCh := make(chan error)
 	go func() {
-		ch <- a.Run()
-		close(ch)
+		errCh <- a.Run()
+		close(errCh)
 	}()
 	a.WaitReady()
 	time.Sleep(50 * time.Millisecond)
 
 	return a, func() {
-		require.NoError(t, <-ch, "Run should exit without any errors")
+		require.NoError(t, <-errCh, "Run should exit without any errors")
 	}
 }
 

--- a/cmd/adsysd/daemon/daemon_test.go
+++ b/cmd/adsysd/daemon/daemon_test.go
@@ -307,6 +307,8 @@ func startDaemon(t *testing.T, setupEnv bool, args ...string) (app *daemon.App, 
 	a := daemon.New()
 	a.SetArgs(args...)
 
+	// Error must be channeled back because failed assertions outside the main
+	// test goroutine will cause a panic.
 	errCh := make(chan error)
 	go func() {
 		errCh <- a.Run()


### PR DESCRIPTION
If a `require` check fails outside of the main goroutine, it causes a panic.

This test is a common pattern in our projects, so I went looking for it after having golangci-lint warn about it in Ubuntu Pro for WSL.