### PR TITLE
fix: allow sssd backend to work without ad_domain

### DIFF
--- a/internal/ad/backends/sss/sss.go
+++ b/internal/ad/backends/sss/sss.go
@@ -59,9 +59,14 @@ func New(ctx context.Context, c Config, bus *dbus.Conn) (s SSS, err error) {
 	if sssdDomain == "" {
 		return SSS{}, errors.New(gotext.Get("failed to find default sssd domain in sssd.conf"))
 	}
-	domain := cfg.Section(fmt.Sprintf("domain/%s", sssdDomain)).Key("ad_domain").String()
+	domainSection := cfg.Section(fmt.Sprintf("domain/%s", sssdDomain))
+	if len(domainSection.KeyStrings()) == 0 {
+		return SSS{}, errors.New(gotext.Get("could not find AD domain section corresponding to %q, or the section is empty", sssdDomain))
+	}
+	domain := domainSection.Key("ad_domain").String()
 	if domain == "" {
-		return SSS{}, errors.New(gotext.Get("could not find AD domain name corresponding to %q", sssdDomain))
+		// If no ad_domain is found, use the domain from the main section
+		domain = sssdDomain
 	}
 
 	if defaultDomainSuffix == "" {

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -46,6 +46,7 @@ func TestSSSD(t *testing.T) {
 		"Can handle special DNS domain characters": {sssdConf: "special-characters.example.com"},
 		"SSSd domain can not match ad domain":      {sssdConf: "domain-no-match-addomain"},
 		"Default domain suffix is read":            {sssdConf: "example.com-with-default-domain-suffix"},
+		"Use domain from section if no ad_domain":  {sssdConf: "example.com-without-ad_domain"},
 
 		// Special cases for config parameters
 		"Regular config, with cache dir": {sssdConf: "example.com", sssdCacheDir: "/some/specific/cachedir"},
@@ -70,6 +71,7 @@ func TestSSSD(t *testing.T) {
 		"Error on empty domains field":         {sssdConf: "empty-domains", wantErr: true},
 		"Error on no sssd section":             {sssdConf: "no-sssd-section", wantErr: true},
 		"Error on sssd domain section missing": {sssdConf: "sssddomain-missing", wantErr: true},
+		"Error on sssd domain empty section":   {sssdConf: "sssddomain-empty-section", wantErr: true},
 	}
 
 	for name, tc := range tests {

--- a/internal/ad/backends/sss/testdata/TestSSSD/configs/example.com-without-ad_domain
+++ b/internal/ad/backends/sss/testdata/TestSSSD/configs/example.com-without-ad_domain
@@ -1,0 +1,5 @@
+[sssd]
+domains = example.com
+
+[domain/example.com]
+id_provider = ad

--- a/internal/ad/backends/sss/testdata/TestSSSD/configs/sssddomain-empty-section
+++ b/internal/ad/backends/sss/testdata/TestSSSD/configs/sssddomain-empty-section
@@ -1,0 +1,4 @@
+[sssd]
+domains=empty-section.com
+
+[domain/empty-section.com]

--- a/internal/ad/backends/sss/testdata/TestSSSD/golden/use_domain_from_section_if_no_ad_domain
+++ b/internal/ad/backends/sss/testdata/TestSSSD/golden/use_domain_from_section_if_no_ad_domain
@@ -1,0 +1,9 @@
+* Domain(): example.com
+* ServerFQDN(): dynamic_active_server.example.com
+* IsOnline(): true
+* HostKrb5CCName(): /var/lib/sss/db/ccache_EXAMPLE.COM
+* DefaultDomainSuffix(): example.com
+* Config():
+Current backend is SSSD
+Configuration: testdata/TestSSSD/configs/example.com-without-ad_domain
+Cache: /var/lib/sss/db


### PR DESCRIPTION
This restores the functionality prior to the refactor in PR #467, where the case of having a domain section without the `ad_domain` setting resorted to using the domain from the `sssd.domains` setting. This is valid behavior supported and [suggested](https://sssd.io/docs/ad/ad-provider-manual.html#id4) by sssd.

In addition to that, avoid being too lenient and still raise an error if the domain section is empty or does not exist.

Fixes #910 / UDENG-2268