### PR TITLE
maint(go): Upgrade to Go 1.22.0

### DIFF
--- a/cmd/adsysd/integration_tests/adsys_test.go
+++ b/cmd/adsysd/integration_tests/adsys_test.go
@@ -121,7 +121,6 @@ socket: %s`, socket)), 0600)
 		"version":                     {args: []string{"version"}},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			_, err = runClient(t, confFile, tc.args...)
 			require.Error(t, err, "command should fail")
@@ -155,7 +154,6 @@ func TestCommandsTimeouts(t *testing.T) {
 		"0 is no timeout": {timeout: 0},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// We only implement one command to test the client timeout functionality
 			timeoutServer := timeoutOnVersionServer{callbackHandled: make(chan struct{})}

--- a/cmd/adsysd/integration_tests/adsysctl_doc_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_doc_test.go
@@ -41,7 +41,6 @@ func TestDocChapter(t *testing.T) {
 		"Error on nonexistent chapter":   {chapter: "nonexistent-chapter", wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.systemAnswer == "" {
 				tc.systemAnswer = "polkit_yes"
@@ -91,7 +90,6 @@ func TestDocCompletion(t *testing.T) {
 		"Empty completion content on daemon not responding": {daemonNotStarted: true, wantCompletionEmpty: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.systemAnswer == "" {
 				tc.systemAnswer = "polkit_yes"

--- a/cmd/adsysd/integration_tests/adsysctl_policy_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_policy_test.go
@@ -41,7 +41,6 @@ func TestPolicyAdmx(t *testing.T) {
 		"Error on daemon not responding": {arg: "lts-only", daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.systemAnswer)
 
@@ -120,7 +119,6 @@ func TestPolicyApplied(t *testing.T) {
 		"Error on daemon not responding":                            {daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.systemAnswer == "" {
 				tc.systemAnswer = "polkit_yes"
@@ -994,7 +992,6 @@ func TestPolicyUpdate(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.systemAnswer == "" {
 				tc.systemAnswer = "polkit_yes"
@@ -1215,7 +1212,6 @@ func TestPolicyDebugScriptDump(t *testing.T) {
 		"Error on daemon not responding for cert-autoenroll": {script: "cert-autoenroll", cmdName: "cert-autoenroll-script", path: "internal/policies/certificate", daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.systemAnswer)
 
@@ -1271,7 +1267,6 @@ func TestPolicyDebugTicketPath(t *testing.T) {
 		"Error if ticket path is a directory": {pathIsDir: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Empty username means current user
 			if tc.username == "" {

--- a/cmd/adsysd/integration_tests/adsysctl_service_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_service_test.go
@@ -37,7 +37,6 @@ func TestServiceStop(t *testing.T) {
 		"Error on daemon not responding": {daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.daemonAnswer)
 
@@ -167,7 +166,6 @@ func TestServiceCat(t *testing.T) {
 		"Error on daemon not responding - cover client": {daemonNotStarted: true, coverCatClient: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.systemAnswer)
 
@@ -299,7 +297,6 @@ func TestServiceStatus(t *testing.T) {
 		"Error on daemon not responding": {daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.systemAnswer)
 

--- a/cmd/adsysd/integration_tests/adsysctl_version_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_version_test.go
@@ -22,7 +22,6 @@ func TestVersion(t *testing.T) {
 		"Error on daemon not responding": {daemonNotStarted: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			dbusAnswer(t, tc.systemAnswer)
 

--- a/cmd/adsysd/integration_tests/adsysd_mount_test.go
+++ b/cmd/adsysd/integration_tests/adsysd_mount_test.go
@@ -64,7 +64,6 @@ func TestAdsysdMount(t *testing.T) {
 		"Errors out and prints usage message when executed with more than 2 arguments": {addArgs: []string{"more", "than", "two"}, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.sessionAnswer == "" {
 				tc.sessionAnswer = "polkit_yes"

--- a/cmd/adsysd/integration_tests/adsysd_scripts_test.go
+++ b/cmd/adsysd/integration_tests/adsysd_scripts_test.go
@@ -40,8 +40,6 @@ func TestAdsysdRunScripts(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/adsysd/main_test.go
+++ b/cmd/adsysd/main_test.go
@@ -58,7 +58,6 @@ func TestRun(t *testing.T) {
 		"Send SIGHUP with exit":       {sendSig: syscall.SIGHUP, hupReturn: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Signal handlers tests: can’t be parallel
 

--- a/cmd/adwatchd/integration_tests/adwatchd_service_test.go
+++ b/cmd/adwatchd/integration_tests/adwatchd_service_test.go
@@ -48,8 +48,6 @@ func TestServiceStateChange(t *testing.T) {
 		"uninstall and restart":    {sequence: []string{"uninstall", "stop"}, wantErrAt: []int{1}},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			var err error
 
@@ -240,8 +238,6 @@ func TestServiceConfigFlagUsage(t *testing.T) {
 		"install": {wantConfig: true},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			r, w, err := os.Pipe()
 			require.NoError(t, err, "Setup: pipe shouldn't fail")

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
                dh-apport,
                dh-golang,
-               golang-go (>= 2:1.21~),
+               golang-go (>= 2:1.22~),
                apparmor,
                dbus,
                libdbus-1-dev,
@@ -20,13 +20,12 @@ Build-Depends: debhelper-compat (= 13),
                samba-dsdb-modules,
 Standards-Version: 4.5.1
 XS-Go-Import-Path: github.com/ubuntu/adsys
-Homepage: https://github.com/ubuntu/adsys
+Homepage: <https://github.com/ubuntu/adsys>
 Description: AD SYStem integration
  ADSys is an AD SYStem tool to integrate GPOs with a linux system.
  It allows one to handle machine and users GPOs, mapping them to dconf keys,
  apparmor rules, mounts, proxy settings, certificate autoenrollment and running
  scripts at different points in time.
-
 
 Package: adsys
 Architecture: any

--- a/e2e/internal/command/command_test.go
+++ b/e2e/internal/command/command_test.go
@@ -53,7 +53,6 @@ func TestInventory(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.fromState == "" {
 				tc.fromState = inventory.Null
@@ -110,7 +109,6 @@ func TestExecute(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.action == nil {
 				tc.action = mockAction

--- a/e2e/scripts/patches/focal.patch
+++ b/e2e/scripts/patches/focal.patch
@@ -10,8 +10,8 @@ index ccf213e0..40a2aa9f 100644
 +Build-Depends: debhelper-compat (= 12),
                 dh-apport,
                 dh-golang,
--               golang-go (>= 2:1.21~),
-+               golang-1.21-go,
+-               golang-go (>= 2:1.22~),
++               golang-1.22-go,
                 apparmor,
                 dbus,
                 libdbus-1-dev,
@@ -23,8 +23,8 @@ index 43646c6a..0708aa3d 100755
  # Tests needing sudo will be skipped automatically
  export ADSYS_SKIP_INTEGRATION_TESTS=1
 
-+# Run with Go 1.21
-+export PATH := /usr/lib/go-1.21/bin/:$(PATH)
++# Run with Go 1.22
++export PATH := /usr/lib/go-1.22/bin/:$(PATH)
 +
  %:
         dh $@ --buildsystem=golang --with=golang,apport

--- a/e2e/scripts/patches/jammy.patch
+++ b/e2e/scripts/patches/jammy.patch
@@ -6,8 +6,8 @@ index ccf213e0..2d34a328 100644
  Build-Depends: debhelper-compat (= 13),
                 dh-apport,
                 dh-golang,
--               golang-go (>= 2:1.21~),
-+               golang-1.21-go,
+-               golang-go (>= 2:1.22~),
++               golang-1.22-go,
                 apparmor,
                 dbus,
                 libdbus-1-dev,
@@ -19,8 +19,8 @@ index 43646c6a..403e7bb9 100755
  # Tests needing sudo will be skipped automatically
  export ADSYS_SKIP_INTEGRATION_TESTS=1
 
-+# Run with Go 1.21
-+export PATH := /usr/lib/go-1.21/bin/:$(PATH)
++# Run with Go 1.22
++export PATH := /usr/lib/go-1.22/bin/:$(PATH)
 +
  %:
 	dh $@ --buildsystem=golang --with=golang,apport

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ubuntu/adsys
 
-go 1.21.0
-
-toolchain go1.21.6
+go 1.22.0
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0

--- a/internal/ad/ad_test.go
+++ b/internal/ad/ad_test.go
@@ -45,7 +45,6 @@ func TestNew(t *testing.T) {
 		"error on backend ServerFQDN random failure": {backendServerFQDNError: errors.New("Some failure on ServerFQDN"), wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			runDir, cacheDir := t.TempDir(), t.TempDir()
@@ -540,7 +539,6 @@ func TestGetPolicies(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
@@ -692,7 +690,6 @@ func TestGetPoliciesOffline(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -833,7 +830,6 @@ func TestGetPoliciesWorkflows(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
@@ -996,7 +992,6 @@ func TestGetPoliciesConcurrently(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
@@ -1155,7 +1150,6 @@ func TestListUsers(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1228,7 +1222,6 @@ func TestGetInfo(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1284,7 +1277,6 @@ func TestNormalizeTargetName(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/admxgen/admxgen_test.go
+++ b/internal/ad/admxgen/admxgen_test.go
@@ -38,9 +38,6 @@ func TestExpand(t *testing.T) {
 		"dconf generation fails":  {root: "unsupported dconf type", wantErr: true},
 	}
 	for name, tc := range tests {
-		name := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -102,9 +99,6 @@ func TestGenerateAD(t *testing.T) {
 		"admx generation fails":    {destIsFile: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		name := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -161,9 +155,6 @@ func TestGenerateDoc(t *testing.T) {
 		"doc generation fails":     {destIsFile: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		name := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/admxgen/dconf/dconf_test.go
+++ b/internal/ad/admxgen/dconf/dconf_test.go
@@ -78,7 +78,6 @@ func TestGenerate(t *testing.T) {
 	}
 	for name, tc := range tests {
 		def := strings.ToLower(strings.ReplaceAll(name, " ", "_"))
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/admxgen/files.go
+++ b/internal/ad/admxgen/files.go
@@ -46,7 +46,6 @@ func Expand(src, dst, root, currentSession string) error {
 	expandedPoliciesStream := make(chan []common.ExpandedPolicy, len(files))
 	var g errgroup.Group
 	for _, f := range files {
-		f := f
 		g.Go(func() error {
 			t := strings.TrimSuffix(strings.ToLower(filepath.Base(f)), ".yaml")
 			if t == "categories" {

--- a/internal/ad/admxgen/internal_test.go
+++ b/internal/ad/admxgen/internal_test.go
@@ -85,10 +85,7 @@ func TestGenerateExpandedCategories(t *testing.T) {
 		"category definition doesn't exist": {wantErrLoadDefinitions: true},
 	}
 	for name, tc := range tests {
-		name := name
 		categoryDefinition := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -167,9 +164,6 @@ func TestExpandedCategoriesToADMX(t *testing.T) {
 		"error on destination creation": {destIsFile: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		name := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			dst := t.TempDir()
@@ -267,9 +261,6 @@ func TestExpandedCategoriesToMD(t *testing.T) {
 		"error on destination creation": {destIsFile: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		name := name
-
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			dst := filepath.Join(t.TempDir(), "subdir")

--- a/internal/ad/adsys-gpolist_test.go
+++ b/internal/ad/adsys-gpolist_test.go
@@ -191,7 +191,6 @@ func TestAdsysGPOList(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if tc.objectClass == "" {
 				tc.objectClass = "user"

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -75,7 +75,6 @@ func TestSSSD(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/backends/winbind/winbind_test.go
+++ b/internal/ad/backends/winbind/winbind_test.go
@@ -52,7 +52,6 @@ func TestWinbind(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Set up mock libwbclient behavior
 			t.Setenv("ADSYS_WBCLIENT_BEHAVIOR", tc.wbclientBehavior)

--- a/internal/ad/common/common_test.go
+++ b/internal/ad/common/common_test.go
@@ -28,8 +28,6 @@ func TestGetVersionID(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/definitions_test.go
+++ b/internal/ad/definitions_test.go
@@ -38,8 +38,6 @@ func TestGetPolicyDefinitions(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/ad/internal_test.go
+++ b/internal/ad/internal_test.go
@@ -281,7 +281,6 @@ func TestFetch(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 			dest, rundir := t.TempDir(), t.TempDir()
@@ -419,7 +418,6 @@ func TestFetchWithUnreadableFile(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 
@@ -469,7 +467,6 @@ func TestFetchTweakSysvolCacheDir(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel() // libsmbclient overrides SIGCHILD, but we have one global lock
 

--- a/internal/ad/krb5_test.go
+++ b/internal/ad/krb5_test.go
@@ -43,7 +43,6 @@ func TestTicketPath(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			wantOut := filepath.Join(t.TempDir(), "krb5cc_12345")
 			if strings.Contains(tc.krb5Behavior, "return_ccache") {

--- a/internal/ad/registry/internal_test.go
+++ b/internal/ad/registry/internal_test.go
@@ -212,9 +212,7 @@ func TestReadPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
-			name := name
 			t.Parallel()
 
 			f, err := os.Open(policyFilePath(name))

--- a/internal/ad/registry/registry_test.go
+++ b/internal/ad/registry/registry_test.go
@@ -374,9 +374,7 @@ func TestDecodePolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
-			name := name
 			t.Parallel()
 
 			f, err := os.Open(policyFilePath(name))

--- a/internal/adsysservice/adsysservice_test.go
+++ b/internal/adsysservice/adsysservice_test.go
@@ -47,7 +47,6 @@ func TestNew(t *testing.T) {
 		"Error on ad.New prevents adsysservice creation": {roDir: "parentcache/cache", wantNewErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/adsysservice/policy.go
+++ b/internal/adsysservice/policy.go
@@ -53,7 +53,6 @@ func (s *Service) UpdatePolicy(r *adsys.UpdatePolicyRequest, stream adsys.Servic
 			}
 			errg := new(errgroup.Group)
 			for _, user := range users {
-				user := user
 				errg.Go(func() (err error) {
 					return s.updatePolicyFor(stream.Context(), false, user, ad.UserObject, "", r.GetPurge())
 				})

--- a/internal/authorizer/authorizer_test.go
+++ b/internal/authorizer/authorizer_test.go
@@ -50,7 +50,6 @@ func TestIsAllowedFromContext(t *testing.T) {
 		"Unauthorizes when user has invalid uid":         {action: myUserOtherAction, userUIDReturn: "NaN", pid: 10000, uid: 1000, wantAuthorized: false},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/authorizer/internal_test.go
+++ b/internal/authorizer/internal_test.go
@@ -59,7 +59,6 @@ func TestIsAllowed(t *testing.T) {
 		"Polkit dbus call errors out": {wantPolkitError: true, pid: 10000, uid: 1000, polkitAuthorize: true, wantAuthorized: false},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,7 +41,6 @@ func TestSetVerboseMode(t *testing.T) {
 		"3 is debug printing callers": {level: 3, wantOut: []string{"debug", "info", "warning", "error"}, wantCaller: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// capture log output (set to stderr, but captured when loading logrus)
 			r, w, err := os.Pipe()
@@ -191,7 +190,6 @@ func TestInit(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			configDir := t.TempDir()
 			prefix := "adsys_config_test"
@@ -375,7 +373,6 @@ func TestLoadConfig(t *testing.T) {
 		/*"Error on undecodable data to": {},*/
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/config/watchd/watchd_test.go
+++ b/internal/config/watchd/watchd_test.go
@@ -30,8 +30,6 @@ func TestConfigFileFromArgs(t *testing.T) {
 		"Error on config argument with no value": {args: "adwatchd.exe -c ", wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -65,8 +63,6 @@ func TestDirsFromConfigFile(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -99,8 +95,6 @@ func TestWriteConfig(t *testing.T) {
 		"Error on absent dirs": {dirs: []string{"dir1", "dir2"}, absentDirs: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			goldPath, err := filepath.Abs(testutils.GoldenPath(t))
 			require.NoError(t, err, "failed to get absolute path")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -119,7 +119,6 @@ func TestSocketActivation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 
 			dir := t.TempDir()
@@ -226,7 +225,6 @@ func TestSdNotifier(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/grpc/grpcerror/grpcerror_test.go
+++ b/internal/grpc/grpcerror/grpcerror_test.go
@@ -35,7 +35,6 @@ func TestFormat(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 
 			err := grpcerror.Format(tc.err, "DaemonName")

--- a/internal/grpc/logconnections/logconnections_test.go
+++ b/internal/grpc/logconnections/logconnections_test.go
@@ -52,7 +52,6 @@ func TestChildRecvMsgAndHandlerCalled(t *testing.T) {
 		"Error when RecvMsg errors out": {recvMsgError: true, wantHandlerNum: 1, wantRecvMsgError: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/grpc/logstreamer/client_test.go
+++ b/internal/grpc/logstreamer/client_test.go
@@ -132,7 +132,6 @@ func TestRecvLogMsg(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/grpc/logstreamer/log_test.go
+++ b/internal/grpc/logstreamer/log_test.go
@@ -167,7 +167,6 @@ func TestSetReportCaller(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			orig := logrus.StandardLogger().ReportCaller
 			defer logrus.SetReportCaller(orig)

--- a/internal/grpc/logstreamer/server_test.go
+++ b/internal/grpc/logstreamer/server_test.go
@@ -109,7 +109,6 @@ func TestStreamServerInterceptorLoggerInvalidMetadata(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/loghooks/eventlog_test.go
+++ b/internal/loghooks/eventlog_test.go
@@ -31,7 +31,6 @@ func TestEventLogHook(t *testing.T) {
 		"debug level": {level: logrus.DebugLevel, wantOut: []string{"debug", "info", "warning", "error"}},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			buf.Reset()
 			log := logrus.New()

--- a/internal/policies/apparmor/apparmor_test.go
+++ b/internal/policies/apparmor/apparmor_test.go
@@ -98,8 +98,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/certificate/cert-autoenroll_test.go
+++ b/internal/policies/certificate/cert-autoenroll_test.go
@@ -110,8 +110,6 @@ func TestCertAutoenrollScript(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			stateDir := t.TempDir()
 			sambaCacheDir := filepath.Join(stateDir, "samba")

--- a/internal/policies/certificate/certificate_test.go
+++ b/internal/policies/certificate/certificate_test.go
@@ -71,7 +71,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Test with a clean PYTHONPATH to avoid differences in the golden file output
 			origPythonPath, existed := os.LookupEnv("PYTHONPATH")

--- a/internal/policies/dconf/dconf_test.go
+++ b/internal/policies/dconf/dconf_test.go
@@ -190,8 +190,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/dconf/internal_test.go
+++ b/internal/policies/dconf/internal_test.go
@@ -104,7 +104,6 @@ func TestNormalize(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/gdm/gdm_test.go
+++ b/internal/policies/gdm/gdm_test.go
@@ -27,8 +27,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/gpo_test.go
+++ b/internal/policies/gpo_test.go
@@ -82,8 +82,6 @@ func TestFormat(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/manager_test.go
+++ b/internal/policies/manager_test.go
@@ -65,8 +65,6 @@ func TestApplyPolicies(t *testing.T) {
 		"Error when applying certificate policy": {policiesDir: "certificate_failing", wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			// We change the dbus returned values to simulate a subscription
 			//t.Parallel()
@@ -285,8 +283,6 @@ func TestDumpPolicies(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -352,8 +348,6 @@ func TestLastUpdateFor(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -408,8 +402,6 @@ func TestGetSubscriptionState(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			// We change the dbus returned values to simulate a subscription
 			//t.Parallel()

--- a/internal/policies/mount/internal_test.go
+++ b/internal/policies/mount/internal_test.go
@@ -40,7 +40,6 @@ func TestParseEntryValues(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -83,7 +82,6 @@ func TestWriteFileWithUIDGID(t *testing.T) {
 	require.NoError(t, err, "Setup: failed to get current user")
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -142,7 +140,6 @@ func TestCreateUnits(t *testing.T) {
 		"Write krb5 tagged unit": {entry: "entry with kerberos auth tag"},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/mount/mount_test.go
+++ b/internal/policies/mount/mount_test.go
@@ -229,6 +229,7 @@ func TestApplyPolicy(t *testing.T) {
 				testutils.CreatePath(t, filepath.Join(p, "not_empty"))
 			}
 
+			// #nosec G601: This is fixed with Go 1.22.0 and is a false positive (https://github.com/securego/gosec/pull/1108)
 			m, err := mount.New(runDir, systemUnitDir, &tc.firstMockSystemdCaller, opts...)
 			require.NoError(t, err, "Setup: Failed to create manager for the tests.")
 
@@ -250,6 +251,7 @@ func TestApplyPolicy(t *testing.T) {
 					e.Disabled = tc.isDisabledSecondCall
 					secondEntries = append(secondEntries, e)
 				}
+				// #nosec G601: This is fixed with Go 1.22.0 and is a false positive (https://github.com/securego/gosec/pull/1108)
 				m.SetSystemdCaller(&tc.secondMockSystemdCaller)
 
 				if tc.pathAlreadyExistsSecondCall {

--- a/internal/policies/mount/mount_test.go
+++ b/internal/policies/mount/mount_test.go
@@ -30,7 +30,6 @@ func TestNew(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,7 +171,6 @@ func TestApplyPolicy(t *testing.T) {
 		"Error when applying system policy and the entry is errored":             {entries: []string{"errored entry"}, isComputer: true, wantErr: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/policies_test.go
+++ b/internal/policies/policies_test.go
@@ -68,8 +68,6 @@ func TestNew(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -117,8 +115,6 @@ func TestNewFromCache(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -204,8 +200,6 @@ func TestSave(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			src := filepath.Join("testdata", "cache", "policies", tc.cacheSrc)
@@ -386,8 +380,6 @@ func TestSaveAssetsTo(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			src := filepath.Join("testdata", "cache", "policies", tc.cacheSrc)
@@ -466,8 +458,6 @@ func TestCompressAssets(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -883,8 +873,6 @@ func TestGetUniqueRules(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/privilege/internal_test.go
+++ b/internal/policies/privilege/internal_test.go
@@ -53,7 +53,6 @@ func TestSplitAndNormalizeUsersAndGroups(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -89,7 +88,6 @@ func TestGetSystemPolkitAdminIdentities(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/privilege/privilege_test.go
+++ b/internal/policies/privilege/privilege_test.go
@@ -89,8 +89,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/proxy/proxy_test.go
+++ b/internal/policies/proxy/proxy_test.go
@@ -72,8 +72,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/policies/scripts/scripts_test.go
+++ b/internal/policies/scripts/scripts_test.go
@@ -32,8 +32,6 @@ func TestNew(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -118,8 +116,6 @@ func TestApplyPolicy(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -238,8 +234,6 @@ func TestRunScripts(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -49,8 +49,6 @@ func TestManageUnit(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/watchdtui/watchdtui_test.go
+++ b/internal/watchdtui/watchdtui_test.go
@@ -328,8 +328,6 @@ func TestInteractiveInput(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
-
 		// Need to capture the absolute path of the package before changing directory
 		// in the subtests, otherwise the tree will change.
 		absPkgPath, _ := filepath.Abs(".")
@@ -479,8 +477,6 @@ func TestInteractiveUpdate(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
-		name := name
 		t.Run(name, func(t *testing.T) {
 			tmpdir := t.TempDir()
 			absPrevDirs := make([]string, len(tc.prevDirs))

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -105,7 +105,6 @@ func TestWatchDirectory(t *testing.T) {
 		"Error on updating malformed GPT.ini": {filesToUpdate: []string{"malformed/new"}, existingDirs: []string{"malformed"}, wantErrBump: true},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/ubuntu/adsys/tools
 
-go 1.21
-
-toolchain go1.21.6
+go 1.22.0
 
 require (
 	github.com/golangci/golangci-lint v1.56.1


### PR DESCRIPTION
Upgrade module and package to Go 1.22.0
Remove loop closure variable redeclaration

Note: once the end to end work is done to run on PR, we need to ensure we include either a ppa with go 1.22.0 or get it backported already to the targetted distro.