### PR TITLE
maint: prepare changelog for 0.14.0 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+adsys (0.14.0) noble; urgency=medium
+
+  * Infer user KRB5CCNAME path via the libkrb5 API (LP: #2049061)
+    - This functionality is opt-in and activated if the detect_cached_ticket
+      setting is set to true
+    - If the AD backend (e.g. sssd) doesn't export the KRB5CCNAME variable, adsys
+      will now determine the path to the default ticket cache and use it during
+      authentication (when adsys is executed through the PAM module) and runs of
+      adsysctl update for the current user.
+  * Allow sssd backend to work without ad_domain being set (LP: #2054445)
+  * Upgrade to Go 1.22
+  * CI and quality of life changes not impacting package functionality:
+    - Pass token explicitly to Codecov action
+    - Fix require outside of main goroutine
+    - Mark function arguments as unused where applicable
+      Thanks to Edu Gómez Escandell
+    - End to end test VM template creation updates
+    - Bump github actions to latest:
+      - codecov/codecov-action
+      - peter-evans/create-pull-request
+  * Update dependencies to latest:
+    - github.com/charmbracelet/bubbles
+    - github.com/golangci/golangci-lint
+    - golang.org/x/crypto
+    - golang.org/x/net
+    - google.golang.org/grpc
+
+ -- Gabriel Nagy <gabriel.nagy@canonical.com>  Tue, 27 Feb 2024 11:58:57 +0200
+
 adsys (0.13.3) noble; urgency=medium
 
   * Fix cert auto-enroll without NDES (LP: #2051363)

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Build-Depends: debhelper-compat (= 13),
                samba-dsdb-modules,
 Standards-Version: 4.5.1
 XS-Go-Import-Path: github.com/ubuntu/adsys
-Homepage: <https://github.com/ubuntu/adsys>
+Homepage: https://github.com/ubuntu/adsys
 Description: AD SYStem integration
  ADSys is an AD SYStem tool to integrate GPOs with a linux system.
  It allows one to handle machine and users GPOs, mapping them to dconf keys,


### PR DESCRIPTION
Fixes UDENG-2350

PPA build [passed](https://launchpad.net/~gabuscus/+archive/ubuntu/ppa/+sourcepub/15820801/+listing-archive-extra) (riscv64 still in progress). I've replaced the go dependencies to satisfy the PPA build, as golang-defaults 2:1.22 is still in proposed. As golang-1.22 is now in main I expect the defaults package to be migrated soon.