### PR TITLE
tests: increase gpolist command timeout for AD tests

### DIFF
--- a/internal/adsysservice/adsysservice.go
+++ b/internal/adsysservice/adsysservice.go
@@ -240,6 +240,7 @@ func New(ctx context.Context, opts ...option) (s *Service, err error) {
 	if args.runDir != "" {
 		adOptions = append(adOptions, ad.WithRunDir(args.runDir))
 	}
+	adOptions = append(adOptions, ad.WithGpoListTimeout(consts.DefaultGpoListTimeout))
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,7 +1,11 @@
 // Package consts defines the constants used by the project
 package consts
 
-import log "github.com/sirupsen/logrus"
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
 
 var (
 	// Version is the version of the executable.
@@ -35,6 +39,9 @@ const (
 
 	// DefaultServiceTimeout is the default time in seconds without any active request before the service exits.
 	DefaultServiceTimeout = 120
+
+	// DefaultGpoListTimeout is the default time to wait for the GPO list subcommand to finish.
+	DefaultGpoListTimeout = 10 * time.Second
 
 	// DistroID is the distro ID which can be overridden at build time.
 	DistroID = "Ubuntu"


### PR DESCRIPTION
As the AD object is initialized multiple times in tests but only once in production I opted for the less intuitive approach of defaulting to the longer timeout and overriding with the production one instead of the other way around.

This should fix the ad tests we've seen time out in armhf autopkgtests.