### PR TITLE
maint: pin go toolchain to 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/adsys
 
 go 1.22.0
 
+toolchain go1.22.1
+
 require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/adsys/tools
 
 go 1.22.0
 
+toolchain go1.22.1
+
 require (
 	github.com/golangci/golangci-lint v1.56.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0


### PR DESCRIPTION
To fix the security vulnerabilities reported by govulncheck, specifically:
- GO-2024-2598
- GO-2024-2599