### PR TITLE
feat(tests): use an env variable to update golden files

### DIFF
--- a/cmd/adsysd/client/policy_test.go
+++ b/cmd/adsysd/client/policy_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"flag"
 	"os"
 	"testing"
 
@@ -51,10 +50,4 @@ Policies from user configuration:
 
 	want := testutils.LoadWithUpdateFromGolden(t, got)
 	require.Equal(t, want, got, "colorizePolicies returned expected formatted output")
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-	m.Run()
 }

--- a/cmd/adsysd/integration_tests/adsys_test.go
+++ b/cmd/adsysd/integration_tests/adsys_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -65,9 +64,6 @@ func TestMain(m *testing.M) {
 		}
 		defer testutils.SetupSmb(1446, filepath.Join(cwd, "testdata/AD/SYSVOL"))()
 	}
-
-	testutils.InstallUpdateFlag()
-	flag.Parse()
 
 	m.Run()
 

--- a/cmd/adsysd/integration_tests/adsysctl_policy_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_policy_test.go
@@ -1170,7 +1170,7 @@ func TestPolicyUpdate(t *testing.T) {
 			require.NoError(t, err, "client should exit with no error")
 
 			goldenPath := testutils.GoldenPath(t)
-			update := testutils.Update()
+			update := testutils.UpdateEnabled()
 			testutils.CompareTreesWithFiltering(t, filepath.Join(adsysDir, "dconf"), filepath.Join(goldenPath, "dconf"), update)
 			testutils.CompareTreesWithFiltering(t, filepath.Join(adsysDir, "sudoers.d"), filepath.Join(goldenPath, "sudoers.d"), update)
 			testutils.CompareTreesWithFiltering(t, filepath.Join(adsysDir, "polkit-1"), filepath.Join(goldenPath, "polkit-1"), update)

--- a/cmd/adsysd/integration_tests/adsysd_scripts_test.go
+++ b/cmd/adsysd/integration_tests/adsysd_scripts_test.go
@@ -83,7 +83,7 @@ func TestAdsysdRunScripts(t *testing.T) {
 
 			// Get and compare oracle file to check order
 			src := filepath.Join(p, "golden")
-			testutils.CompareTreesWithFiltering(t, src, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, src, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/ad/admxgen/admxgen_test.go
+++ b/internal/ad/admxgen/admxgen_test.go
@@ -175,7 +175,7 @@ func TestGenerateDoc(t *testing.T) {
 			}
 			require.NoError(t, err, "GenerateDoc failed but shouldn't have")
 
-			testutils.CompareTreesWithFiltering(t, dst, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dst, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/ad/admxgen/dconf/dconf_test.go
+++ b/internal/ad/admxgen/dconf/dconf_test.go
@@ -1,7 +1,6 @@
 package dconf_test
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,11 +107,4 @@ func TestGenerate(t *testing.T) {
 			assert.Equal(t, want, got, "expected and got differs")
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/ad/admxgen/internal_test.go
+++ b/internal/ad/admxgen/internal_test.go
@@ -1,7 +1,6 @@
 package admxgen
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -287,11 +286,4 @@ func TestExpandedCategoriesToMD(t *testing.T) {
 			testutils.CompareTreesWithFiltering(t, dst, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/ad/admxgen/internal_test.go
+++ b/internal/ad/admxgen/internal_test.go
@@ -284,7 +284,7 @@ func TestExpandedCategoriesToMD(t *testing.T) {
 			}
 			require.NoError(t, err, "expandedCategoriesToMD failed but shouldn't have")
 
-			testutils.CompareTreesWithFiltering(t, dst, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dst, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -137,7 +137,6 @@ func (s sssdbus) IsOnline() (bool, *dbus.Error) {
 }
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
 	// TODO: do we want to alway print debug?
 	debug := flag.Bool("verbose", false, "Print debug log level information within the test")
 	flag.Parse()

--- a/internal/ad/backends/winbind/winbind_test.go
+++ b/internal/ad/backends/winbind/winbind_test.go
@@ -125,7 +125,6 @@ func TestExecuteKinitCommand(_ *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
 	debug := flag.Bool("verbose", false, "Print debug log level information within the test")
 	flag.Parse()
 	if *debug {

--- a/internal/ad/internal_test.go
+++ b/internal/ad/internal_test.go
@@ -579,9 +579,6 @@ func TestParseGPOConcurrent(t *testing.T) {
 const SmbPort = 1445
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
 	// Don’t setup samba or sssd for mock helpers
 	if strings.Contains(strings.Join(os.Args, " "), "TestMock") {
 		m.Run()

--- a/internal/config/watchd/watchd_test.go
+++ b/internal/config/watchd/watchd_test.go
@@ -2,7 +2,6 @@ package watchd_test
 
 import (
 	"context"
-	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,11 +129,4 @@ func TestWriteConfig(t *testing.T) {
 			require.ElementsMatch(t, tc.dirs, got)
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/config/watchd/watchd_test.go
+++ b/internal/config/watchd/watchd_test.go
@@ -120,7 +120,7 @@ func TestWriteConfig(t *testing.T) {
 			}
 			require.NoError(t, err, "didn't expect writing config to fail")
 
-			if testutils.Update() {
+			if testutils.UpdateEnabled() {
 				err := os.MkdirAll(filepath.Dir(goldPath), 0750)
 				require.NoError(t, err, "Setup: Failed to create path to store the golden files")
 				testutils.Copy(t, configPath, goldPath)

--- a/internal/policies/apparmor/apparmor_test.go
+++ b/internal/policies/apparmor/apparmor_test.go
@@ -170,7 +170,7 @@ func TestApplyPolicy(t *testing.T) {
 				})
 				require.NoError(t, err, "Setup: can't restore permissions of dumped files")
 			}
-			testutils.CompareTreesWithFiltering(t, apparmorDir, filepath.Join(testutils.GoldenPath(t), "etc", "apparmor.d", "adsys"), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, apparmorDir, filepath.Join(testutils.GoldenPath(t), "etc", "apparmor.d", "adsys"), testutils.UpdateEnabled())
 
 			// Check that apparmor_parser was called with the expected arguments
 			got, err := os.ReadFile(parserCmdOutputFile)

--- a/internal/policies/apparmor/apparmor_test.go
+++ b/internal/policies/apparmor/apparmor_test.go
@@ -3,7 +3,6 @@ package apparmor_test
 import (
 	"bufio"
 	"context"
-	"flag"
 	"fmt"
 	"io/fs"
 	"os"
@@ -312,11 +311,4 @@ func mockLoadedPoliciesFile(t *testing.T, policies []string) string {
 	err := os.WriteFile(path, []byte(strings.Join(policies, " (enforce)\n")+" (enforce)\n"), 0600)
 	require.NoError(t, err, "Setup: Can't write loaded policies file")
 	return path
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/policies/certificate/certificate_test.go
+++ b/internal/policies/certificate/certificate_test.go
@@ -2,7 +2,6 @@ package certificate_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -170,9 +169,6 @@ func TestMockAutoenrollScript(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
 	m.Run()
 	testutils.MergeCoverages()
 }

--- a/internal/policies/dconf/dconf_test.go
+++ b/internal/policies/dconf/dconf_test.go
@@ -219,7 +219,7 @@ func TestApplyPolicy(t *testing.T) {
 			}
 			require.NoError(t, err, "ApplyPolicy failed but shouldn't have")
 
-			testutils.CompareTreesWithFiltering(t, dconfDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dconfDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/dconf/dconf_test.go
+++ b/internal/policies/dconf/dconf_test.go
@@ -2,7 +2,6 @@ package dconf_test
 
 import (
 	"context"
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -222,11 +221,4 @@ func TestApplyPolicy(t *testing.T) {
 			testutils.CompareTreesWithFiltering(t, dconfDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/policies/gdm/gdm_test.go
+++ b/internal/policies/gdm/gdm_test.go
@@ -2,7 +2,6 @@ package gdm_test
 
 import (
 	"context"
-	"flag"
 	"path/filepath"
 	"testing"
 
@@ -50,11 +49,4 @@ func TestApplyPolicy(t *testing.T) {
 			testutils.CompareTreesWithFiltering(t, dconfDir, filepath.Join(testutils.GoldenPath(t), "etc", "dconf"), testutils.UpdateEnabled())
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/policies/gdm/gdm_test.go
+++ b/internal/policies/gdm/gdm_test.go
@@ -47,7 +47,7 @@ func TestApplyPolicy(t *testing.T) {
 			}
 			require.NoError(t, err, "ApplyPolicy failed but shouldn't have")
 
-			testutils.CompareTreesWithFiltering(t, dconfDir, filepath.Join(testutils.GoldenPath(t), "etc", "dconf"), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dconfDir, filepath.Join(testutils.GoldenPath(t), "etc", "dconf"), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/manager_test.go
+++ b/internal/policies/manager_test.go
@@ -177,7 +177,7 @@ func TestApplyPolicies(t *testing.T) {
 				require.NoError(t, err, "ApplyPolicy should return no error but got one")
 			}
 
-			testutils.CompareTreesWithFiltering(t, fakeRootDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, fakeRootDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/mount/internal_test.go
+++ b/internal/policies/mount/internal_test.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"context"
-	"flag"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -157,10 +156,4 @@ func TestCreateUnits(t *testing.T) {
 			testutils.CompareTreesWithFiltering(t, unitPath, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-	m.Run()
 }

--- a/internal/policies/mount/internal_test.go
+++ b/internal/policies/mount/internal_test.go
@@ -124,7 +124,7 @@ func TestWriteFileWithUIDGID(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "writeFileWithUIDGID should not have returned an error but did")
-			testutils.CompareTreesWithFiltering(t, path, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, path, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -154,7 +154,7 @@ func TestCreateUnits(t *testing.T) {
 				require.NoError(t, err, "Setup: Failed to write unit file for comparison.")
 			}
 
-			testutils.CompareTreesWithFiltering(t, unitPath, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, unitPath, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/mount/mount_test.go
+++ b/internal/policies/mount/mount_test.go
@@ -272,7 +272,7 @@ func TestApplyPolicy(t *testing.T) {
 			if !tc.isComputer {
 				makeIndependentOfCurrentUID(t, runDir, u.Uid)
 			}
-			testutils.CompareTreesWithFiltering(t, rootDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, rootDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/policies_test.go
+++ b/internal/policies/policies_test.go
@@ -3,7 +3,6 @@ package policies_test
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io/fs"
 	"log"
@@ -905,9 +904,6 @@ func equalPoliciesToGolden(t *testing.T, got policies.Policies, golden string, u
 }
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
 	// Don’t setup samba or sssd for mock helpers
 	if !strings.Contains(strings.Join(os.Args, " "), "TestMock") {
 		// Ubuntu Advantage

--- a/internal/policies/policies_test.go
+++ b/internal/policies/policies_test.go
@@ -79,7 +79,7 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err, "New should return no error but got one")
 			defer got.Close()
 
-			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.Update())
+			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -126,7 +126,7 @@ func TestNewFromCache(t *testing.T) {
 			require.NoError(t, err, "NewFromCache should return no error but got one")
 			defer got.Close()
 
-			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.Update())
+			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -251,7 +251,7 @@ func TestSave(t *testing.T) {
 			}
 			require.NoError(t, err, "Save should return no error but got one")
 
-			testutils.CompareTreesWithFiltering(t, dest, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dest, testutils.GoldenPath(t), testutils.UpdateEnabled())
 			// compare that assets compressed db corresponds to source.
 			testutils.CompareTreesWithFiltering(t, filepath.Join(dest, policies.PoliciesAssetsFileName), filepath.Join(src, policies.PoliciesAssetsFileName), false)
 
@@ -415,7 +415,7 @@ func TestSaveAssetsTo(t *testing.T) {
 			}
 			require.NoError(t, err, "SaveAssetsTo should return no error but got one")
 
-			testutils.CompareTreesWithFiltering(t, dest, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, dest, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -513,7 +513,7 @@ func TestCompressAssets(t *testing.T) {
 			require.NoError(t, err, "Teardown: NewFromCache should return no error but got one")
 			defer got.Close()
 
-			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.Update())
+			equalPoliciesToGolden(t, got, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/privilege/privilege_test.go
+++ b/internal/policies/privilege/privilege_test.go
@@ -128,7 +128,7 @@ func TestApplyPolicy(t *testing.T) {
 			}
 			require.NoError(t, err, "ApplyPolicy failed but shouldn't have")
 
-			testutils.CompareTreesWithFiltering(t, tempEtc, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, tempEtc, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/privilege/privilege_test.go
+++ b/internal/policies/privilege/privilege_test.go
@@ -2,7 +2,6 @@ package privilege_test
 
 import (
 	"context"
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -131,11 +130,4 @@ func TestApplyPolicy(t *testing.T) {
 			testutils.CompareTreesWithFiltering(t, tempEtc, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/policies/scripts/scripts_test.go
+++ b/internal/policies/scripts/scripts_test.go
@@ -165,7 +165,7 @@ func TestApplyPolicy(t *testing.T) {
 
 			makeIndependentOfCurrentUID(t, runDir, u.Uid)
 
-			testutils.CompareTreesWithFiltering(t, runDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, runDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -277,7 +277,7 @@ func TestRunScripts(t *testing.T) {
 
 			// Get and compare oracle file to check order
 			src := filepath.Join(scriptRootParentDir, "golden")
-			testutils.CompareTreesWithFiltering(t, src, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, src, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/policies/scripts/scripts_test.go
+++ b/internal/policies/scripts/scripts_test.go
@@ -3,7 +3,6 @@ package scripts_test
 import (
 	"context"
 	"errors"
-	"flag"
 	"io/fs"
 	"os"
 	"os/user"
@@ -293,11 +292,4 @@ func (s mockUnitStarter) StartUnit(_ context.Context, _ string) error {
 		return errors.New("failed to start unit")
 	}
 	return nil
-}
-
-func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
-	m.Run()
 }

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,18 @@ import (
 )
 
 var update bool
+
+const (
+	// UpdateGoldenFilesEnv is the environment variable used to indicate go test that
+	// the golden files should be overwritten with the current test results.
+	UpdateGoldenFilesEnv = `TESTS_UPDATE_GOLDEN`
+)
+
+func init() {
+	if os.Getenv(UpdateGoldenFilesEnv) != "" {
+		update = true
+	}
+}
 
 type goldenOptions struct {
 	goldenPath string
@@ -105,12 +116,6 @@ func GoldenPath(t *testing.T) string {
 	}
 
 	return path
-}
-
-// InstallUpdateFlag install an update flag referenced in this package.
-// The flags need to be parsed before running the tests.
-func InstallUpdateFlag() {
-	flag.BoolVar(&update, "update", false, "update golden files")
 }
 
 // UpdateEnabled returns true if updating the golden files is requested.

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -113,7 +113,7 @@ func InstallUpdateFlag() {
 	flag.BoolVar(&update, "update", false, "update golden files")
 }
 
-// Update returns true if the update flag was set, false otherwise.
-func Update() bool {
+// UpdateEnabled returns true if updating the golden files is requested.
+func UpdateEnabled() bool {
 	return update
 }

--- a/internal/watchdtui/watchdtui_test.go
+++ b/internal/watchdtui/watchdtui_test.go
@@ -649,7 +649,6 @@ func TestMain(m *testing.M) {
 	// Simulate a color terminal
 	lipgloss.SetColorProfile(termenv.ANSI256)
 
-	testutils.InstallUpdateFlag()
 	flag.BoolVar(&stdout, "stdout", false, "print output to stdout for debugging purposes")
 	flag.Parse()
 


### PR DESCRIPTION
Use TESTS_UPDATE_GOLDEN to update golden files
This will allow to update all golden files in one go, without having to endure the update flag installation and potential warning that the flag is not supported in some packages.
Align check if update flag is enabled on other projects.

UDENG-2468