### PR TITLE
build: include journal errors and adsys logs in apport report

### DIFF
--- a/debian/adsys.apport
+++ b/debian/adsys.apport
@@ -4,6 +4,9 @@
 '''
 
 import apport.hookutils
+import re
 
 def add_info(report):
     apport.hookutils.attach_related_packages(report, ["sssd", "python3-samba"])
+    apport.hookutils.attach_journal_errors(report, 600)
+    report['Syslog'] = apport.hookutils.recent_syslog(re.compile("adsys"))


### PR DESCRIPTION
To reduce the back and forth with bug reporters, update our apport hook to attach more helpful information to reports.

We now include journal errors around the report timestamp (+/- 10 minutes), and any journal messages containing "adsys" -- this includes logs emitted by the service and possibly more messages referring to adsys which do not necessarily come from the service.

Fixes #944 / UDENG-2489

Bug report diff:
```diff
--- /tmp/bug-before	2024-03-21 12:01:05.118875773 +0200
+++ /tmp/bug	2024-03-21 11:59:57.613523157 +0200
@@ -315,6 +315,28 @@
 DistroRelease: Ubuntu 24.04
 InstallationDate: Installed on 2022-06-29 (631 days ago)
 InstallationMedia: Ubuntu 22.04 LTS "Jammy Jellyfish" - Release amd64 (20220419)
+JournalErrors:
+ mar 21 11:50:26 hostname kernel: kauditd_printk_skb: 87 callbacks suppressed
+ mar 21 11:50:29 hostname systemd[3027]: tracker-extract-3.service: Main process exited, code=dumped, status=31/SYS
+ mar 21 11:50:29 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:29 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:50:30 hostname systemd[3027]: tracker-extract-3.service: Main process exited, code=dumped, status=31/SYS
+ mar 21 11:50:30 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:30 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:50:31 hostname systemd[3027]: tracker-extract-3.service: Main process exited, code=dumped, status=31/SYS
+ mar 21 11:50:31 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:31 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:50:33 hostname systemd[3027]: tracker-extract-3.service: Main process exited, code=dumped, status=31/SYS
+ mar 21 11:50:33 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:33 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:50:34 hostname systemd[3027]: tracker-extract-3.service: Main process exited, code=dumped, status=31/SYS
+ mar 21 11:50:34 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:34 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:50:34 hostname systemd[3027]: tracker-extract-3.service: Start request repeated too quickly.
+ mar 21 11:50:34 hostname systemd[3027]: tracker-extract-3.service: Failed with result 'core-dump'.
+ mar 21 11:50:34 hostname systemd[3027]: Failed to start tracker-extract-3.service - Tracker metadata extractor.
+ mar 21 11:59:51 hostname systemd[1]: adsysd.service: Failed with result 'exit-code'.
+ mar 21 11:59:51 hostname systemd[1]: Failed to start adsysd.service - ADSys daemon service.
 NonfreeKernelModules: nvidia_modeset nvidia
 Package: adsys 0.13.3 [modified: usr/share/apport/package-hooks/adsys.py]
 PackageArchitecture: amd64
@@ -367,6 +389,26 @@
  sssd          2.9.4-1ubuntu1
  python3-samba 2:4.19.5+dfsg-1ubuntu1
 SourcePackage: adsys
+Syslog:
+ mar 21 11:40:23 canterbury systemd[1]: adsys-boot.service - Refresh ADSys GPO for machine on boot was skipped because of an unmet condition check (ConditionPathExists=/etc/sssd/sssd.conf).
+ mar 21 11:40:23 canterbury systemd[1]: Started adsys-gpo-refresh.timer - Refresh ADSys GPO for machine and users.
+ mar 21 11:40:23 canterbury systemd[1]: adsys-machine-scripts.service - ADSys machine startup and shutdown scripts execution was skipped because of an unmet condition check (ConditionPathExists=/run/adsys/machine/scripts/.ready).
+ mar 21 11:40:23 canterbury systemd[1]: Listening on adsysd.socket - Socket activation for ADSys daemon.
+ mar 21 11:40:23 canterbury systemd[1]: Mounting run-adsys.mount - Allow /run/adsys to execute binaries: machine and user scripts are downloaded there...
+ mar 21 11:40:23 canterbury systemd[1]: Mounted run-adsys.mount - Allow /run/adsys to execute binaries: machine and user scripts are downloaded there.
+ mar 21 11:44:31 canterbury systemd[1]: Starting adsysd.service - ADSys daemon service...
+ mar 21 11:44:31 canterbury adsysd[59514]: level=error msg="couldn't create adsys service: could not initialize AD backend: can't get domain configuration from {Conf:/etc/sssd/sssd.conf CacheDir:/var/lib/sss/db}: open /etc/sssd/sssd.conf: no such file or directory"
+ mar 21 11:44:31 canterbury systemd[1]: adsysd.service: Main process exited, code=exited, status=1/FAILURE
+ mar 21 11:44:31 canterbury systemd[1]: adsysd.service: Failed with result 'exit-code'.
+ mar 21 11:44:31 canterbury systemd[1]: Failed to start adsysd.service - ADSys daemon service.
+ mar 21 11:59:51 canterbury systemd[1]: Starting adsysd.service - ADSys daemon service...
+ mar 21 11:59:51 canterbury adsysd[61662]: level=error msg="couldn't create adsys service: could not initialize AD backend: can't get domain configuration from {Conf:/etc/sssd/sssd.conf CacheDir:/var/lib/sss/db}: open /etc/sssd/sssd.conf: no such file or directory"
+ mar 21 11:59:51 canterbury systemd[1]: adsysd.service: Main process exited, code=exited, status=1/FAILURE
+ mar 21 11:59:51 canterbury systemd[1]: adsysd.service: Failed with result 'exit-code'.
+ mar 21 11:59:51 canterbury systemd[1]: Failed to start adsysd.service - ADSys daemon service.
+
 Tags: noble
 Uname: Linux 6.6.0-14-generic x86_64
 UpgradeStatus: Upgraded to noble on 2023-11-21 (120 days ago)
```