### PR TITLE
feat(coverage): ship Corbertura assets as a zip for our partner

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -101,11 +101,18 @@ jobs:
         with:
           file: ./coverage/codecov/Cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Publish coverage as a release artifact
+
+      # For quality indicator model partner measure.
+      - name: Compress coverage for release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        run: cd ./coverage/codecov/ && zip ../Cobertura.xml.zip ./Cobertura.xml
+      - name: Publish coverage as a release asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./coverage/codecov/Cobertura.xml
+          files: |
+            ./coverage/codecov/Cobertura.xml
+            ./coverage/Cobertura.xml.zip
 
   adwatchd-tests:
     name: Windows tests for adwatchd


### PR DESCRIPTION
They are requiring a zip file instead of the xml directly. Ship both of it so that we still link the xml directly from README.

UDENG-2555