### PR TITLE
fix(e2e): fix argument for az sig image-version create

### DIFF
--- a/e2e/cmd/build_base_image/02_create_vm_template/main.go
+++ b/e2e/cmd/build_base_image/02_create_vm_template/main.go
@@ -116,7 +116,7 @@ func action(ctx context.Context, cmd *command.Command) error {
 		"--gallery-image-version", nextImageVersion,
 		"--target-regions", "westeurope", "eastus=1=standard_zrs",
 		"--replica-count", "2",
-		"--managed-image", inv.VMID,
+		"--virtual-machine", inv.VMID,
 		"--tags", "project=AD", "subproject=adsys-e2e-tests",
 	)
 	if err != nil {


### PR DESCRIPTION
It appears there's been a regression in version 2.59.0 of the Azure CLI, where az sig image-version create fails when being passed the --managed-image flag, see the related [failing CI run](https://github.com/ubuntu/adsys/actions/runs/8677801641/job/23793927248
), and the [reported issue](https://github.com/Azure/azure-cli/issues/28700) on the azure-cli project.

Because of this we are not able to create new versions for any of our VM templates.

To fix this we can apply the workaround from the linked issue and pass the VM ID inside the `--virtual-machine` argument. I've tested this locally and successfully created a new image version with the change.

Partly fixes UDENG-2528