### PR TITLE
fix(e2e): disable systemd-networkd-wait-online on Noble

### DIFF
--- a/e2e/scripts/provision.sh
+++ b/e2e/scripts/provision.sh
@@ -29,11 +29,11 @@ echo "Updating DNS resolver to use AD DNS..."
 echo "DNS=10.1.0.4" >> /etc/systemd/resolved.conf
 systemctl restart systemd-resolved
 
-# Work around an issue on Jammy where systemd-networkd times out due to eth0
-# losing connectivity shortly after boot, even though network works fine as
-# reported by Azure.
-if [ "$(lsb_release -cs)" = "jammy" ]; then
-    echo "Disabling systemd-networkd-wait-online.service on jammy..."
+# Work around an issue on Jammy and Noble where systemd-networkd times out due
+# to eth0 losing connectivity shortly after boot, even though network works fine
+# as reported by Azure.
+if [[ "$(lsb_release -cs)" =~ ^(jammy|noble)$ ]]; then
+    echo "Disabling misbehaving systemd-networkd-wait-online.service..."
     systemctl mask systemd-networkd-wait-online.service
 fi
 


### PR DESCRIPTION
We already did this for Jammy and it appears that Noble exhibits the same issue which causes provisioning to take 2 minutes longer than usual (due to the timing out).

What's surprising to me is that we didn't need to do the same for Lunar or Mantic and I'm afraid I don't have a logical explanation for this, but hey... it works!

```
Apr 24 12:54:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: Started systemd-networkd.service - Network Configuration.
Apr 24 12:54:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd-networkd[669]: eth0: Link UP
Apr 24 12:54:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd-networkd[669]: eth0: Gained carrier
Apr 24 12:54:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: Starting systemd-networkd-wait-online.service - Wait for Network to be Configured...
Apr 24 12:54:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd-networkd[669]: eth0: Gained IPv6LL
Apr 24 12:54:41 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: systemd-fsckd.service: Deactivated successfully.
Apr 24 12:54:49 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a kernel: hv_balloon: Max. dynamic memory size: 4096 MB
Apr 24 12:56:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd-networkd-wait-online[670]: Timeout occurred while waiting for network connectivity.
Apr 24 12:56:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: systemd-networkd-wait-online.service: Main process exited, code=exited, status=1/FAILURE
Apr 24 12:56:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: systemd-networkd-wait-online.service: Failed with result 'exit-code'.
Apr 24 12:56:18 adsys-e2e-template-noble-54d0ed77-2d35-49ed-8823-4047188a7b9a systemd[1]: Failed to start systemd-networkd-wait-online.service - Wait for Network to be Configured.
```

Partly fixes UDENG-2528