### PR TITLE
tests(e2e): enable e2e tests on Noble

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,11 +49,6 @@ jobs:
                   continue
               fi
 
-              # FIXME: Noble images are currently broken, so avoid testing them for now
-              if [ "${r}" = "noble" ]; then
-                  continue
-              fi
-
               if [ -n "${releases}" ]; then
                   releases="${releases}, "
               fi


### PR DESCRIPTION
Now that we have functional VM image templates for Noble we can stop excluding it from test runs.

Passing run on fork: https://github.com/GabrielNagy/adsys/actions/runs/8832525087

Fixes UDENG-2528