### PR TITLE
Change coverage publish to nightly prerelease

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -103,16 +103,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       # For quality indicator model partner measure.
-      - name: Compress coverage for release asset
-        if: startsWith(github.ref, 'refs/tags/')
-        run: cd ./coverage/codecov/ && zip ../Cobertura.xml.zip ./Cobertura.xml
-      - name: Publish coverage as a release asset
+      - name: Publish coverage as a nightly release asset
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main'
         with:
-          files: |
-            ./coverage/codecov/Cobertura.xml
-            ./coverage/Cobertura.xml.zip
+          prerelease: true
+          name: nightly
+          tag_name: nightly
+          files: ./coverage/codecov/Cobertura.xml
+          fail_on_unmatched_files: true
 
   adwatchd-tests:
     name: Windows tests for adwatchd

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Active Directory GPO support.
 
 [![Code quality](https://github.com/ubuntu/adsys/workflows/QA/badge.svg)](https://github.com/ubuntu/adsys/actions?query=workflow%3AQA)
 [![Code coverage](https://codecov.io/gh/ubuntu/adsys/branch/main/graph/badge.svg)](https://codecov.io/gh/ubuntu/adsys)
-[![Download XML coverage report](https://img.shields.io/badge/xml%20coverage%20report-download-green)](https://github.com/ubuntu/adsys/releases/latest/download/Cobertura.xml)
+[![Download XML coverage report](https://img.shields.io/badge/xml%20coverage%20report-download-green)](https://github.com/ubuntu/adsys/releases/download/nightly/Cobertura.xml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ubuntu/adsys.svg)](https://pkg.go.dev/github.com/ubuntu/adsys)
 [![Go Report Card](https://goreportcard.com/badge/ubuntu/adsys)](https://goreportcard.com/report/ubuntu/adsys)
 [![License](https://img.shields.io/badge/License-GPL3.0-blue.svg)](https://github.com/ubuntu/adsys/blob/main/LICENSE)


### PR DESCRIPTION
In short, this saves us from an additional test suite run in our forthcoming TiCS scheduled workflow.

Update the coverage report to be uploaded as a pre-release artifact on every 'main' commit -- the consumer can then simply perform a request like the following to download the file:

https://github.com/ubuntu/adsys/releases/download/nightly/Cobertura.xml

A caveat of this approach is that the tag has to exist, and the ref the tag is pointing to will not change. Unfortunately there's no one size fits all solution for this that:
- handles creating the tag
- keeps the ref up to date
- replaces the coverage asset with the latest

I think these are reasonable drawbacks since tag creation is a one-time action, and we don't (yet) need the tag to point to the latest ref.

Part of UDENG-2756