### PR TITLE
ci: add TiCS cron job workflow

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -1,0 +1,51 @@
+name: Code quality nightly scan
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+env:
+  apt_dependencies: >-
+    ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev
+    libkrb5-dev libwbclient-dev pkg-config python3-coverage samba sudo
+    libglib2.0-dev gvfs
+
+jobs:
+  tics:
+    name: TIOBE TiCS Framework
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ env.apt_dependencies }}
+      - name: TiCS scan
+        env:
+          TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+
+          # Download and move coverage to the right place so TiCS can parse it
+          RUN_ID=$(gh run list --workflow 'QA & sanity checks' --limit 1 --status completed --json databaseId -b main | jq '.[].databaseId')
+          gh run download $RUN_ID -n coverage.zip
+          mkdir .coverage
+          mv Cobertura.xml .coverage/coverage.xml
+
+          # Install TiCS
+          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+
+          # TiCS requires all artifacts to be built
+          go build ./cmd/...
+
+          TICSQServer -project adsys -tmpdir /tmp/tics -branchdir .
+          tar -cvzf tics-logs.tar.gz /tmp/tics
+      - name: Upload TiCS logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: tics-logs.zip
+          path: tics-logs.tar.gz


### PR DESCRIPTION
Because the TiCS suite takes quite a long time to install and run, our best bet is to run it on a nightly basis as a scheduled job. I've selected 4 AM UTC as the start time, this should be a quiet as no one is supposed to be working at this hour on any of our team's timezones (I hope), so no risk of changes coming through while the workflow is running.

To set up TiCS itself, we follow TIOBE's guidelines, namely:
- place the coverage in the expected location
- install TiCS
- compile all of our binaries
- run TiCS
- archive and upload logs as artifacts

Fixes UDENG-2756

-------------

You can see a passing run of this workflow here: https://github.com/GabrielNagy/adsys/actions/runs/9034819300/job/24828572639