### PR TITLE
ci: stop publishing coverage as a release artifact

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Upload XML coverage report as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage.xml
+          name: coverage.zip
           path: ./coverage/codecov/Cobertura.xml
       - name: Run tests (with race detector)
         run: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -102,18 +102,6 @@ jobs:
           file: ./coverage/codecov/Cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # For quality indicator model partner measure.
-      - name: Compress coverage for release asset
-        if: startsWith(github.ref, 'refs/tags/')
-        run: cd ./coverage/codecov/ && zip ../Cobertura.xml.zip ./Cobertura.xml
-      - name: Publish coverage as a release asset
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            ./coverage/codecov/Cobertura.xml
-            ./coverage/Cobertura.xml.zip
-
   adwatchd-tests:
     name: Windows tests for adwatchd
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Active Directory GPO support.
 
 [![Code quality](https://github.com/ubuntu/adsys/workflows/QA/badge.svg)](https://github.com/ubuntu/adsys/actions?query=workflow%3AQA)
 [![Code coverage](https://codecov.io/gh/ubuntu/adsys/branch/main/graph/badge.svg)](https://codecov.io/gh/ubuntu/adsys)
-[![Download XML coverage report](https://img.shields.io/badge/xml%20coverage%20report-download-green)](https://github.com/ubuntu/adsys/releases/latest/download/Cobertura.xml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ubuntu/adsys.svg)](https://pkg.go.dev/github.com/ubuntu/adsys)
 [![Go Report Card](https://goreportcard.com/badge/ubuntu/adsys)](https://goreportcard.com/report/ubuntu/adsys)
 [![License](https://img.shields.io/badge/License-GPL3.0-blue.svg)](https://github.com/ubuntu/adsys/blob/main/LICENSE)


### PR DESCRIPTION
Now that we've decided to rely on workflow artifacts for coverage handling, there's no need to publish these on releases anymore.

I've removed the code responsible for this, together with the README badge.

--------------

Because of the minor change to the artifact extension this has to go in before #993.