### PR TITLE
tests(e2e): skip tests on Oracular until images are available

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,6 +49,11 @@ jobs:
                   continue
               fi
 
+              # TODO remove this once we have Docker & Azure images for Oracular
+              if [ "${r}" = "oracular" ]; then
+                  continue
+              fi
+
               if [ -n "${releases}" ]; then
                   releases="${releases}, "
               fi


### PR DESCRIPTION
Currently e2e tests [are failing](https://github.com/ubuntu/adsys/actions/runs/9155417330/job/25175939564) on Oracular because there's no Docker image for it yet so we cannot build the adsys deb. On top of this, we don't have an Azure VM template for it either.

We should revisit this in a month or two as the new version stabilizes.