### PR TITLE
fix(ci): get coverage artifact from last successful job

### DIFF
--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -32,7 +32,7 @@ jobs:
           set -e
 
           # Download and move coverage to the right place so TiCS can parse it
-          RUN_ID=$(gh run list --workflow 'QA & sanity checks' --limit 1 --status completed --json databaseId -b main | jq '.[].databaseId')
+          RUN_ID=$(gh run list --workflow 'QA & sanity checks' --limit 1 --status success --json databaseId -b main | jq '.[].databaseId')
           gh run download $RUN_ID -n coverage.zip
           mkdir .coverage
           mv Cobertura.xml .coverage/coverage.xml


### PR DESCRIPTION
Previously we would get it from the last _completed_ job which was not necessarily passing so it didn't guarantee that our coverage artifact got uploaded.

To fix this, go for the last successful job instead.

Example failing run: https://github.com/ubuntu/adsys/actions/runs/9344222405/job/25715014478