### PR TITLE
ci: install staticcheck in TiCS scanner job

### DIFF
--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ env.apt_dependencies }}
+          go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: TiCS scan
         env:
           TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
The scanner penalizes us because staticcheck is not installed. Let's install it to get some extra points.