### PR TITLE
maint: bump Go toolchain version for vulnerability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys/tools
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/golangci/golangci-lint v1.59.0


### PR DESCRIPTION
Vulnerability 1: GO-2024-2888
    Mishandling of corrupt central directory record in archive/zip
  More info: https://pkg.go.dev/vuln/GO-2024-2888
  Standard library
    Found in: archive/zip@go1.22.3
    Fixed in: archive/zip@go1.22.4

Vulnerability 2: GO-2024-2887
    Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in
    net/netip
  More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net/netip@go1.22.3
    Fixed in: net/netip@go1.22.4