### PR TITLE
packaging: remove broken prerm purge stanza

### DIFF
--- a/debian/adsys.prerm
+++ b/debian/adsys.prerm
@@ -5,12 +5,4 @@ if [ "$1" = remove ] && [ "${DPKG_MAINTSCRIPT_PACKAGE_REFCOUNT:-1}" = 1 ]; then
         pam-auth-update --package --remove adsys
 fi
 
-if [ "$1" = purge ] && [ "${DPKG_MAINTSCRIPT_PACKAGE_REFCOUNT:-1}" = 1 ]; then
-        adsysctl policy purge -a
-        rm -rf /var/cache/adsys
-        # Remove adsys-managed machine dconf database
-        rm -f /etc/dconf/db/machine
-        rm -rf /etc/dconf/db/machine.d
-fi
-
 #DEBHELPER#


### PR DESCRIPTION
It was pointed to us that dpkg NEVER calls a prerm script with an argument of 'purge'; 'purge' is only ever given as an argument to a postrm script, so this bit of code never actually worked. ([ref](https://wiki.debian.org/MaintainerScripts
))

Interestingly hundreds of packages in the wild fall in [this pitfall](https://github.com/search?q=purge+path%3Adebian%2F+path%3A**%2F*prerm&type=Code), so we are not the only victims here.

I'm choosing to remove the stanza altogether since there's no (simple) way for us to execute `adsysctl` in a purge context, and I don't consider having this working to be a huge win for the project.

Because this functionality was never documented properly in the changelog (the full changelog entry is: "Add adsysctl policy purge command to purge applied policies"), no actual public-facing promises were made, so I don't see the point in us documenting the removal of this hiccup either.