### PR TITLE
ci: switch to team PPA for Azure VPN

### DIFF
--- a/.github/actions/azure-sstpc-vpn/action.yaml
+++ b/.github/actions/azure-sstpc-vpn/action.yaml
@@ -25,7 +25,7 @@ runs:
     - name: Install required packages from PPA
       shell: bash
       run: |
-        sudo add-apt-repository -y ppa:gabuscus/ppp
+        sudo add-apt-repository -y ppa:ubuntu-enterprise-desktop/ppp
         sudo apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y sstp-client
     - name: Write certificate data to disk


### PR DESCRIPTION
I've repackaged `ppp` and `sstp-client` in the team PPA for both Jammy and Noble, so that we are not affected by when the `ubuntu-latest` runner transitions to Noble on GitHub Actions.

Here's a passing run with `ubuntu-latest` (aka 22.04): https://github.com/GabrielNagy/adsys/actions/runs/9502739724
And with `ubuntu-24.04`: https://github.com/GabrielNagy/adsys/actions/runs/9506065559

Fixes UDENG-3048