### PR TITLE
ci: fix failing TICS check

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -11,7 +11,7 @@ env:
   apt_dependencies: >-
     ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev
     libkrb5-dev libwbclient-dev pkg-config python3-coverage samba sudo
-    libglib2.0-dev gvfs
+    libglib2.0-dev gvfs libpam0g-dev
 
 jobs:
   sanity:
@@ -31,6 +31,9 @@ jobs:
           golangci-lint-configfile: ".golangci-ci.yaml"
           tools-directory: "tools"
           generate-diff-paths-to-ignore: po/* docs/**/*.md README.md
+          go-build-script: |
+            go build ./...
+            go generate -x -tags=tools ./pam
       - name: C code formatting
         uses: jidicula/clang-format-action@v4.13.0
         with:

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -45,8 +45,11 @@ jobs:
           go build ./cmd/...
 
           TICSQServer -project adsys -tmpdir /tmp/tics -branchdir .
-          tar -cvzf tics-logs.tar.gz /tmp/tics
+      - name: Archive TiCS logs
+        if: ${{ always() }}
+        run: tar -cvzf tics-logs.tar.gz /tmp/tics
       - name: Upload TiCS logs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: tics-logs.zip

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -9,7 +9,7 @@ env:
   apt_dependencies: >-
     ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev
     libkrb5-dev libwbclient-dev pkg-config python3-coverage samba sudo
-    libglib2.0-dev gvfs
+    libglib2.0-dev gvfs libpam0g-dev
 
 jobs:
   tics:

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -47,7 +47,7 @@ jobs:
           TICSQServer -project adsys -tmpdir /tmp/tics -branchdir .
       - name: Archive TiCS logs
         if: ${{ always() }}
-        run: tar -cvzf tics-logs.tar.gz /tmp/tics
+        run: tar -cvzf tics-logs.tar.gz /tmp/tics build.log
       - name: Upload TiCS logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The TICS job was failing because it couldn't build the PAM module.
Indeed, the required dependency was not installed. To improve upon this a bit, install it and make sure we build the PAM module as part of the sanity checks too.

I've also included some small improvements in the TICS workflow such as archiving and uploading the logs regardless of job status.

Fixes UDENG-3155

Passing TICS run: https://github.com/GabrielNagy/adsys/actions/runs/9513279430/job/26223035380