### PR TITLE
tests(e2e): re-enable e2e tests on Oracular

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,11 +49,6 @@ jobs:
                   continue
               fi
 
-              # TODO remove this once we have Docker & Azure images for Oracular
-              if [ "${r}" = "oracular" ]; then
-                  continue
-              fi
-
               if [ -n "${releases}" ]; then
                   releases="${releases}, "
               fi


### PR DESCRIPTION
We discussed this yesterday and came to the conclusion that it's better to run the Oracular cell even if an image template doesn't exist yet. It will fail the job, but this way we will notice when a template is finally built (the job will turn green), and no action will be required of the team.