### PR TITLE
maint: remove TICS log uploads

### DIFF
--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -48,12 +48,3 @@ jobs:
           go build ./cmd/...
 
           TICSQServer -project adsys -tmpdir /tmp/tics -branchdir .
-      - name: Archive TiCS logs
-        if: ${{ always() }}
-        run: tar -cvzf tics-logs.tar.gz /tmp/tics build.log
-      - name: Upload TiCS logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: tics-logs.zip
-          path: tics-logs.tar.gz


### PR DESCRIPTION
This was leaking the GITHUB_TOKEN which was active for a short period of time, as shown by researcher.
Disabling the upload from their advice.