### PR TITLE
docs: Change to GB spelling

### DIFF
--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -2,7 +2,7 @@ matrix:
 - name: rST files
   aspell:
     lang: en
-    d: en_US
+    d: en_GB
   dictionary:
     wordlists:
     - .wordlist.txt

--- a/docs/explanation/apparmor.md
+++ b/docs/explanation/apparmor.md
@@ -146,7 +146,7 @@ It is also recommended to define a `DEFAULT` subprofile as part of the system-wi
 }
 ```
 
-## Profile parsing behaviors
+## Profile parsing behaviours
 
 ### Troubleshooting misbehaving user profiles
 

--- a/docs/explanation/certificates.md
+++ b/docs/explanation/certificates.md
@@ -1,10 +1,10 @@
-# Certificate auto-enrollment
+# Certificate auto-enrolment
 
-The certificate policy manager allows clients to enroll for certificates from **Active Directory Certificate Services**. Certificates are then continuously monitored and refreshed by the [`certmonger`](https://www.freeipa.org/page/Certmonger) daemon. Currently, only machine certificates are supported.
+The certificate policy manager allows clients to enrol for certificates from **Active Directory Certificate Services**. Certificates are then continuously monitored and refreshed by the [`certmonger`](https://www.freeipa.org/page/Certmonger) daemon. Currently, only machine certificates are supported.
 
-Unlike the other ADSys policy managers which are configured in the special Ubuntu section provided by the ADMX files (Administrative Templates), settings for certificate auto-enrollment are configured in the Microsoft GPO tree:
+Unlike the other ADSys policy managers which are configured in the special Ubuntu section provided by the ADMX files (Administrative Templates), settings for certificate auto-enrolment are configured in the Microsoft GPO tree:
 
-* Computer Configuration > Policies > Windows Settings > Security Settings > Public Key Policies > Certificate Services Client - Auto-Enrollment
+* `Computer Configuration > Policies > Windows Settings > Security Settings > Public Key Policies > Certificate Services Client - Auto-Enrollment`
 
 ![Certificate GPO tree view](../images/explanation/certificates/certificate-settings.png)
 
@@ -12,7 +12,7 @@ Unlike the other ADSys policy managers which are configured in the special Ubunt
 
 This feature is available only for subscribers of **Ubuntu Pro** and has been tested and known to work on all Ubuntu versions starting with 22.04 (Jammy).
 
-Additionally, the following packages must be installed on the client in order for auto-enrollment to work:
+Additionally, the following packages must be installed on the client in order for auto-enrolment to work:
 
 * [`certmonger`](https://www.freeipa.org/page/Certmonger) - daemon that monitors and updates certificates
 * [`cepces`](https://github.com/openSUSE/cepces) - `certmonger` extension that can communicate with **Active Directory Certificate Services**
@@ -25,17 +25,17 @@ sudo apt install certmonger python3-cepces
 
 On the Windows side, the following roles must be installed and configured:
 
-* Certification Authority
-* Certificate Enrollment Policy Web Service
-* Certificate Enrollment Web Service
+* `Certification Authority`
+* `Certificate Enrollment Policy Web Service`
+* `Certificate Enrollment Web Service`
 
 ## Rules precedence
 
-Auto-enrollment configuration will override any settings referenced higher in the GPO hierarchy.
+Auto-enrolment configuration will override any settings referenced higher in the GPO hierarchy.
 
 ## Policy configuration
 
-Certificate auto-enrollment is configured by setting the **Configuration Model** to **Enabled** and ticking the following checkbox: **Update certificates that use certificate templates**.
+Certificate auto-enrolment is configured by setting the **Configuration Model** to **Enabled** and ticking the following checkbox: **Update certificates that use certificate templates**.
 
 ![Certificate GPO properties](../images/explanation/certificates/certificate-gpo.png)
 
@@ -48,13 +48,13 @@ The other settings in this GPO entry do not affect ADSys in any way.
 
 For more advanced configuration, a list of policy servers can be specified in the following GPO entry:
 
-* Computer Configuration > Policies > Windows Settings > Security Settings > Public Key Policies > Certificate Services Client - Certificate Enrollment Policy
+* `Computer Configuration > Policies > Windows Settings > Security Settings > Public Key Policies > Certificate Services Client - Certificate Enrollment Policy`
 
 ![Certificate advanced configuration](../images/explanation/certificates/advanced-configuration.png)
 
 ## Applying the policy
 
-On the client system, a successful auto-enrollment will place certificate data in the following paths:
+On the client system, a successful auto-enrolment will place certificate data in the following paths:
 
 * `/var/lib/adsys/certs` - certificate data
 * `/var/lib/adsys/private/certs` - private key data
@@ -97,7 +97,7 @@ CA 'galacticcafe-CA':
 
 ## Policy implementation
 
-With the exception of policy parsing, ADSys leverages the Samba implementation of certificate auto-enrollment. As this feature is only available in newer versions of Samba, we have taken the liberty of vendoring the required Samba files to allow this policy to work on Ubuntu versions that ship an older Samba version. These files are shipped in `/usr/share/adsys/python/vendor_samba`.
+With the exception of policy parsing, ADSys leverages the Samba implementation of certificate auto-enrolment. As this feature is only available in newer versions of Samba, we have taken the liberty of vendoring the required Samba files to allow this policy to work on Ubuntu versions that ship an older Samba version. These files are shipped in `/usr/share/adsys/python/vendor_samba`.
 
 To ensure idempotency when applying the policy, we set up a Samba [TDB cache file](https://wiki.samba.org/index.php/TDB) at `/var/lib/adsys/samba/cert_gpo_state_$(hostname).tdb` which contains various information pertaining to the enrolled certificate(s).
 
@@ -134,9 +134,9 @@ CA "galacticcafe-CA" removed.
 
 Note that tampering with certificate data outside of ADSys (e.g. manually unmonitoring using `getcert`) will render the GPO cache obsolete as it will cause a drift between the actual state and the "known" cached state. In this case, it's best to remove the cache file at `/var/lib/adsys/samba/*.tdb` together with any enrolled certificates and CAs to ensure a clean slate.
 
-### Debugging auto-enroll script
+### Debugging `auto-enroll` script
 
-While certificate parsing happens in ADSys itself, enrollment is done via an embedded Python helper script. For debugging purposes, it can be dumped to the current directory and made executable by executing the following commands:
+While certificate parsing happens in ADSys itself, enrolment is done via an embedded Python helper script. For debugging purposes, it can be dumped to the current directory and made executable by executing the following commands:
 
 ```output
 > adsysctl policy debug cert-autoenroll-script
@@ -172,4 +172,4 @@ While configuring Active Directory Certificate Services is outside the scope of 
 
 ## Acknowledgements
 
-We would like to thank the Samba team for making great strides in the research and implementation of certificate auto-enrollment via Active Directory Certificate Services.
+We would like to thank the Samba team for making great strides in the research and implementation of certificate auto-enrolment via Active Directory Certificate Services.

--- a/docs/explanation/dconf.md
+++ b/docs/explanation/dconf.md
@@ -6,7 +6,7 @@ Some settings are globally enforced on the machine while other are per-user spec
 
 ## Example of settings
 
-- Change the login screen layout and background color.
+- Change the login screen layout and background colour.
 - Set and lock the default applications in the launcher.
 - Set and lock the user wallpaper.
 - Set the date and time format of the clock.

--- a/docs/explanation/network-shares.md
+++ b/docs/explanation/network-shares.md
@@ -12,7 +12,7 @@ The mount process for these mounts is triggered at the moment a client logs in. 
 
 All protocols supported by the [mount command](https://manpages.ubuntu.com/manpages/jammy/en/man8/mount.8.html) should work out of the box. However, the only tested ones are `smb`, `ftp` and `nfs`.
 
-The backends for the protocols `smb` and `nfs` are automatically enabled when installing the adsys package. In order to enable the backend for `ftp` mounts, the user must install the recommended `curlftpfs` package. This behavior is tested on Ubuntu and might differ on other Linux distributions.
+The backends for the protocols `smb` and `nfs` are automatically enabled when installing the adsys package. In order to enable the backend for `ftp` mounts, the user must install the recommended `curlftpfs` package. This behaviour is tested on Ubuntu and might differ on other Linux distributions.
 
 Access control and file permissions should be configured on the shared location.
 
@@ -24,7 +24,7 @@ User mount policies are located under `Computer Configuration > Policies > Admin
 
 The form is a list of shared drives that should be mounted for the client machine. They must follow the structure `{protocol}://{host name or ip address}/{shared location}`.
 
-The default mount behavior is to mount the listed shares anonymously. In order to require kerberos authentication for the mount process, the tag `[krb5]` can be added as a prefix to the listed share, i.e. `[krb5]{protocol}://{host name or ip address}/{shared location}`.
+The default mount behaviour is to mount the listed shares anonymously. In order to require kerberos authentication for the mount process, the tag `[krb5]` can be added as a prefix to the listed share, i.e. `[krb5]{protocol}://{host name or ip address}/{shared location}`.
 
 Additional mount options are not supported yet.
 

--- a/docs/explanation/proxy.md
+++ b/docs/explanation/proxy.md
@@ -35,7 +35,7 @@ The `System proxy configuration` category provides a list of configurable proxy 
 
 ![HTTP proxy setting in GPO editor](../images/explanation/proxy/system-proxy-settings-focus.png)
 
-Configured settings will then be forwarded to `ubuntu-proxy-manager` which will apply them on all supported backends (e.g. environment variables, APT, GSettings). For an up-to-date list of supported backends, proxy formats and behaviors, refer to the ubuntu-proxy-manager [documentation](https://github.com/ubuntu/ubuntu-proxy-manager/blob/main/README.md).
+Configured settings will then be forwarded to `ubuntu-proxy-manager` which will apply them on all supported backends (e.g. environment variables, APT, GSettings). For an up-to-date list of supported backends, proxy formats and behaviours, refer to the ubuntu-proxy-manager [documentation](https://github.com/ubuntu/ubuntu-proxy-manager/blob/main/README.md).
 
 ### Disabling proxy settings
 

--- a/docs/explanation/scripts.md
+++ b/docs/explanation/scripts.md
@@ -55,7 +55,7 @@ The form is a list of scripts path, relative to the `scripts/` subdirectory of y
 
 This GPO won’t refer any scripts for execution.
 
-## Scripts behaviors
+## Scripts behaviours
 
 ### Scripts erroring out
 

--- a/docs/how-to/join-ad-manually.md
+++ b/docs/how-to/join-ad-manually.md
@@ -2,7 +2,7 @@
 
 ADSys supports two Active Directory backends:
 
-1. [SSSD](https://sssd.io/), or System Security Services Daemon, provides access to centralized identity management systems like Microsoft Active Directory, OpenLDAP, and various other directory servers. This client component retrieves and caches data from remote directory servers, delivering identity, authentication, and authorization services to the host machine.
+1. [SSSD](https://sssd.io/), or System Security Services Daemon, provides access to centralised identity management systems like Microsoft Active Directory, OpenLDAP, and various other directory servers. This client component retrieves and caches data from remote directory servers, delivering identity, authentication, and authorisation services to the host machine.
 2. [Winbind](https://wiki.samba.org/index.php/Configuring_Winbindd_on_a_Samba_AD_DC) is a component of the Samba suite that provides seamless integration and authentication services between UNIX or Linux systems and Windows-based networks, allowing the former to appear as members in a Windows Active Directory domain.
 
 ## Join manually using SSSD

--- a/docs/how-to/set-up-adsys.md
+++ b/docs/how-to/set-up-adsys.md
@@ -39,11 +39,11 @@ Options such as the home directory path template, shell and others can be tweake
 
 ADSys relies on the configured AD backend (e.g. SSSD) to export the `KRB5CCNAME` environment variable pointing to a valid Kerberos ticket cache when a domain user performs authentication.
 
-If for any reason the backend doesn't export the variable but _does_ initialize a ticket cache in the [default path](https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name), ADSys can be configured to infer the path to the ticket cache (via the libkrb5 API) and export it as the `KRB5CCNAME` variable during both authentication and runs of `adsysctl update` for the current domain user.
+If for any reason the backend doesn't export the variable but _does_ initialise a ticket cache in the [default path](https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name), ADSys can be configured to infer the path to the ticket cache (via the libkrb5 API) and export it as the `KRB5CCNAME` variable during both authentication and runs of `adsysctl update` for the current domain user.
 
 To opt into this functionality, the following must be added to `/etc/adsys.yaml`:
 ```yaml
 detect_cached_ticket: true
 ```
 
-With this setting active, ADSys attempts to determine and export the path to the ticket cache. To avoid unexpected behaviors like rejecting authentication for non-domain users, no action is taken if the path returned by the libkrb5 API does not exist on disk.
+With this setting active, ADSys attempts to determine and export the path to the ticket cache. To avoid unexpected behaviours like rejecting authentication for non-domain users, no action is taken if the path returned by the libkrb5 API does not exist on disk.

--- a/docs/how-to/set-up-adwatchd.md
+++ b/docs/how-to/set-up-adwatchd.md
@@ -6,7 +6,7 @@ At its core, the program can be simplified to the following steps:
 
 - watch a list of user-configured directories for changes -- subdirectories are also watched, but only the root directory will have a `GPT.ini` file
 - when a change is detected, attempt to locate a `GPT.ini` file at the root of the watched directory, or create one if absent
-- if a `GPT.ini` file is found, increment the version stanza of the file by 1, thus signaling clients that a new version of the assets (including scripts) are available to download during the next client refresh
+- if a `GPT.ini` file is found, increment the version stanza of the file by 1, thus signalling clients that a new version of the assets (including scripts) are available to download during the next client refresh
 
 ## Installation
 
@@ -43,7 +43,7 @@ For a better understanding on what directories should be configured for watching
 
 Note that the interactive configuration tool can only be run if the `adwatchd` service is not already installed on the machine. Please refer to the [CLI usage](#CLI usage) section for instructions on how to finely manage the service.
 
-We recommend making use of the interactive configuration tool to install the application, as it provides a level of error handling, taking care of path normalization and the creation of the configuration file.
+We recommend making use of the interactive configuration tool to install the application, as it provides a level of error handling, taking care of path normalisation and the creation of the configuration file.
 
 The configuration file is stored as a YAML file, and can be freely edited after the application has been installed. The following keys are configurable:
 

--- a/docs/how-to/use-gpo.md
+++ b/docs/how-to/use-gpo.md
@@ -37,7 +37,7 @@ The change is now visible on the greeter.
 ### Modifying an user setting
 
 1. Let's create another GPO in `warthogs.biz > IT Dept > RnD`.
-1. Select the list of favorite desktop applications setting in `User Configuration > Policies > Administrative Templates > Ubuntu  > Desktop > Shell > List of desktop file IDs for favorite applications`.
+1. Select the list of favourite desktop applications setting in `User Configuration > Policies > Administrative Templates > Ubuntu  > Desktop > Shell > List of desktop file IDs for favorite applications`.
 1. Enter a list of valid .desktop file IDs, one per line, like the following:
 
 ```
@@ -46,7 +46,7 @@ snap-store_ubuntu-software.desktop
 yelp.desktop
 ```
 
-![Favorite applications settings](../images/how-to/use-gpo/gpo_setting_enabled_list_of_apps.png)
+![Favourite applications settings](../images/how-to/use-gpo/gpo_setting_enabled_list_of_apps.png)
 
 4. Refresh the GPO rule applied to the user by logging in or running `adsysctl update` as your current user or `adsysctl update --all` to refresh the computer and all active users.
 
@@ -103,7 +103,7 @@ The **right pane** of the GPO Management editor contains the general information
 
 #### Text entry
 
-The type `Text` represents a single line of text. If you don’t enclose a string with single quotes `'` and the value is not a decimal, it will be done automatically and the entry will be sanitized  (e.g. space, `'`…). If you want to force a decimal to be treated as a string, enclose the value with single quotes.
+The type `Text` represents a single line of text. If you don’t enclose a string with single quotes `'` and the value is not a decimal, it will be done automatically and the entry will be sanitised  (e.g. space, `'`…). If you want to force a decimal to be treated as a string, enclose the value with single quotes.
 
 The default value will be already set.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ ADSys enables system administrators to manage Ubuntu Desktop clients centrally v
 
 It simplifies the task of configuring Ubuntu systems in a Microsoft Active Directory environment. However, it doesn't handle user authentication or initial security policy, which are managed by SSSD/Winbind and PAM.
 
-ADSys is valuable for system administrators who wish to manage Ubuntu Desktop clients in a centralized manner through Microsoft Active Directory.
+ADSys is valuable for system administrators who wish to manage Ubuntu Desktop clients in a centralised manner through Microsoft Active Directory.
 
 ```{toctree}
 :hidden:

--- a/docs/reference/adsys-daemon.md
+++ b/docs/reference/adsys-daemon.md
@@ -89,7 +89,7 @@ The ADSys daemon is started on demand by systemd’s socket activation and only 
 
 ## Configuration
 
-`ADSys` doesn’t ship a configuration file by default. However, such a file can be created to modify the behavior of the daemon and the client.
+`ADSys` doesn’t ship a configuration file by default. However, such a file can be created to modify the behaviour of the daemon and the client.
 
 The configuration file can be system-wide in `/etc/adsys.yaml`. This will thus apply to both daemon and client. You can have per-user configuration by creating `$HOME/adsys.yaml`. It will then affect only the client for this user.
 
@@ -190,9 +190,9 @@ Only privileged users have access to this information. As with any other command
 
 More information is available in the [next chapter](adsysctl.md) covering adsysctl cat command.
 
-## Authorizations
+## Authorisations
 
-**ADSys** uses a privilege mechanism based on polkit to manage authorizations. Many commands require elevated privileges to be executed. If the adsys client is executed with insufficient privileges to execute a command, the user will be prompted to enter its password. If allowed then the command will be executed and denied otherwise.
+**ADSys** uses a privilege mechanism based on polkit to manage authorisations. Many commands require elevated privileges to be executed. If the adsys client is executed with insufficient privileges to execute a command, the user will be prompted to enter its password. If allowed then the command will be executed and denied otherwise.
 
 ![Polkit authentication dialog](../images/reference/adsys-daemon/daemon-polkit.png)
 

--- a/docs/reference/adsysctl.md
+++ b/docs/reference/adsysctl.md
@@ -2,7 +2,7 @@
 
 `adsysctl` is a command line utility to request actions from the daemon and query its current status. You can get more verbose output with the `-v` accumulative flags, which will stream all logs from the service corresponding to your specific request.
 
-As a general rule, favor shell completion and the help command for discovering various parts of the adsysctl user interface. It will help you by completing subcommands, flags, users and even chapters of the offline documentation!
+As a general rule, favour shell completion and the help command for discovering various parts of the adsysctl user interface. It will help you by completing subcommands, flags, users and even chapters of the offline documentation!
 
 ## Which policies are applied
 

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Computer Scripts/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Computer Scripts/index.md
@@ -1,0 +1,8 @@
+# Computer Scripts
+
+```{toctree}
+:maxdepth: 99
+
+shutdown
+startup
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Computer Scripts/shutdown.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Computer Scripts/shutdown.md
@@ -1,12 +1,12 @@
 # Shutdown scripts
 
 Define scripts that are executed on machine power off.
-Those scripts are ordered, one by line, and relative to SYSVOL/ubuntu/scripts/ directory.
+Those scripts are ordered, one by line, and relative to `SYSVOL/ubuntu/scripts/` directory.
 Scripts from this GPO will be appended to the list of scripts referenced higher in the GPO hierarchy.
 
 
 - Type: scripts
-- Key: /shutdown
+- Key: `/shutdown`
 
 Note: -
  * Enabled: The scripts in the text entry are executed at shutdown time.
@@ -24,7 +24,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Computer Scripts -> Shutdown scripts    |
-| Registry Key | Software\Policies\Ubuntu\scripts\shutdown         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Computer Scripts -> Shutdown scripts`    |
+| Registry Key | `Software\Policies\Ubuntu\scripts\shutdown`         |
 | Element type | multiText |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/ambient-enabled.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/ambient-enabled.md
@@ -3,10 +3,10 @@
 If the ambient light sensor functionality is enabled.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/ambient-enabled
+- Key: `/org/gnome/settings-daemon/plugins/power/ambient-enabled`
 - Default: true
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured`  and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Enable the ALS sensor    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\ambient-enabled         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Enable the ALS sensor`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\ambient-enabled`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/idle-brightness.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/idle-brightness.md
@@ -3,10 +3,10 @@
 This is the laptop panel screen brightness used when the session is idle.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/idle-brightness
+- Key: `/org/gnome/settings-daemon/plugins/power/idle-brightness`
 - Default: 30
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> The brightness of the screen when idle    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\idle-brightness         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> The brightness of the screen when idle`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\idle-brightness`         |
 | Element type | decimal |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/idle-dim.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/idle-dim.md
@@ -3,10 +3,10 @@
 If the screen should be dimmed to save power when the computer is idle.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/idle-dim
+- Key: `/org/gnome/settings-daemon/plugins/power/idle-dim`
 - Default: true
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Dim the screen after a period of inactivity    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\idle-dim         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Dim the screen after a period of inactivity`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\idle-dim`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/index.md
@@ -1,0 +1,18 @@
+# Power Management
+
+```{toctree}
+:maxdepth: 99
+
+ambient-enabled
+idle-brightness
+idle-dim
+lid-close-ac-action
+lid-close-battery-action
+lid-close-suspend-with-external-monitor
+power-button-action
+power-saver-profile-on-low-battery
+sleep-inactive-ac-timeout
+sleep-inactive-ac-type
+sleep-inactive-battery-timeout
+sleep-inactive-battery-type
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-ac-action.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-ac-action.md
@@ -3,7 +3,7 @@
 The action to take when the laptop lid is closed and the laptop is on AC power.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/lid-close-ac-action
+- Key: `/org/gnome/settings-daemon/plugins/power/lid-close-ac-action`
 - Default: 'suspend'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -25,7 +25,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid close action when on AC    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-ac-action         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid close action when on AC`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-ac-action`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-battery-action.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-battery-action.md
@@ -3,7 +3,7 @@
 The action to take when the laptop lid is closed and the laptop is on battery power.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/lid-close-battery-action
+- Key: `/org/gnome/settings-daemon/plugins/power/lid-close-battery-action`
 - Default: 'suspend'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -25,7 +25,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid close action on battery    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-battery-action         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid close action on battery`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-battery-action`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-suspend-with-external-monitor.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/lid-close-suspend-with-external-monitor.md
@@ -1,9 +1,9 @@
 # Laptop lid, when closed, will suspend even if there is an external monitor plugged in
 
-With no external monitors plugged in, closing a laptop's lid will suspend the machine (as set by the lid-close-battery-action and lid-close-ac-action keys).  By default, however, closing the lid when an external monitor is present will not suspend the machine, so that one can keep working on that monitor (e.g. for docking stations or media viewers).  Set this key to False to keep the default behavior, or to True to suspend the laptop whenever the lid is closed and regardless of external monitors.
+With no external monitors plugged in, closing a laptop's lid will suspend the machine (as set by the lid-close-battery-action and lid-close-ac-action keys).  By default, however, closing the lid when an external monitor is present will not suspend the machine, so that one can keep working on that monitor (e.g. for docking stations or media viewers).  Set this key to False to keep the default behaviour, or to True to suspend the laptop whenever the lid is closed and regardless of external monitors.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/lid-close-suspend-with-external-monitor
+- Key: `/org/gnome/settings-daemon/plugins/power/lid-close-suspend-with-external-monitor`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid, when closed, will suspend even if there is an external monitor plugged in    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-suspend-with-external-monitor         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Laptop lid, when closed, will suspend even if there is an external monitor plugged in`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\lid-close-suspend-with-external-monitor`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/power-button-action.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/power-button-action.md
@@ -1,9 +1,9 @@
 # Power button action
 
-The action to take when the system power button is pressed. Virtual machines only honor the 'nothing' action, and will shutdown otherwise. Tablets always suspend, ignoring all the other action options.
+The action to take when the system power button is pressed. Virtual machines only honour the 'nothing' action, and will shutdown otherwise. Tablets always suspend, ignoring all the other action options.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/power-button-action
+- Key: `/org/gnome/settings-daemon/plugins/power/power-button-action`
 - Default: 'interactive'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -22,7 +22,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Power button action    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\power-button-action         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Power button action`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\power-button-action`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/power-saver-profile-on-low-battery.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/power-saver-profile-on-low-battery.md
@@ -3,7 +3,7 @@
 Automatically enable the "power-saver" profile using power-profiles-daemon if the battery is low.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/power-saver-profile-on-low-battery
+- Key: `/org/gnome/settings-daemon/plugins/power/power-saver-profile-on-low-battery`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Enable power-saver profile when battery is low    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\power-saver-profile-on-low-battery         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Enable power-saver profile when battery is low`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\power-saver-profile-on-low-battery`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-ac-timeout.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-ac-timeout.md
@@ -3,7 +3,7 @@
 The amount of time in seconds the computer on AC power needs to be inactive before it goes to sleep. A value of 0 means never.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-timeout
+- Key: `/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-timeout`
 - Default: 0
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Sleep timeout computer when on AC    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-ac-timeout         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Sleep timeout computer when on AC`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-ac-timeout`         |
 | Element type | decimal |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-ac-type.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-ac-type.md
@@ -3,7 +3,7 @@
 The type of sleeping that should be performed when the computer is inactive.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-type
+- Key: `/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-type`
 - Default: 'suspend'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -25,7 +25,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Whether to hibernate, suspend or do nothing when inactive    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-ac-type         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Whether to hibernate, suspend or do nothing when inactive`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-ac-type`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-battery-timeout.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-battery-timeout.md
@@ -3,7 +3,7 @@
 The amount of time in seconds the computer on battery power needs to be inactive before it goes to sleep. A value of 0 means never.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-timeout
+- Key: `/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-timeout`
 - Default for 20.04: 1200
 - Default for 22.04: 1200
 - Default for 24.04: 900
@@ -19,7 +19,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Sleep timeout computer when on battery    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-battery-timeout         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Sleep timeout computer when on battery`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-battery-timeout`         |
 | Element type | decimal |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-battery-type.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Power Management/sleep-inactive-battery-type.md
@@ -3,7 +3,7 @@
 The type of sleeping that should be performed when the computer is inactive.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-type
+- Key: `/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-type`
 - Default: 'suspend'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -25,7 +25,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Power Management -> Whether to hibernate, suspend or do nothing when inactive    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-battery-type         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Power Management -> Whether to hibernate, suspend or do nothing when inactive`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\power\sleep-inactive-battery-type`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/allow-local-admins.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/allow-local-admins.md
@@ -4,7 +4,7 @@ This allows or prevents client machine to have local users gaining administrator
 
 
 - Type: privilege
-- Key: /allow-local-admins
+- Key: `/allow-local-admins`
 
 Note: -
  * Enabled: This leaves the default rules for the “sudo” and “admin” rule intact.
@@ -19,7 +19,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Privilege Authorization -> Allow local administrators    |
-| Registry Key | Software\Policies\Ubuntu\privilege\allow-local-admins         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Privilege Authorization -> Allow local administrators`    |
+| Registry Key | `Software\Policies\Ubuntu\privilege\allow-local-admins`         |
 | Element type |  |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/client-admins.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/client-admins.md
@@ -1,11 +1,11 @@
 # Client administrators
 
 Define users and groups from AD allowed to administer client machines.
-It must be of the form user@domain or %group@domain. One per line.
+It must be of the form `user@domain` or `%group@domain`. One per line.
 
 
 - Type: privilege
-- Key: /client-admins
+- Key: `/client-admins`
 
 Note: -
  * Enabled: This allows defining Active Directory groups and users with administrative privileges in the box entry.
@@ -20,7 +20,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> Privilege Authorization -> Client administrators    |
-| Registry Key | Software\Policies\Ubuntu\privilege\client-admins         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> Privilege Authorization -> Client administrators`    |
+| Registry Key | `Software\Policies\Ubuntu\privilege\client-admins`         |
 | Element type | multiText |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/Privilege Authorisation/index.md
@@ -1,0 +1,8 @@
+# Privilege Authorisation
+
+```{toctree}
+:maxdepth: 99
+
+allow-local-admins
+client-admins
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System Drive Mapping/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System Drive Mapping/index.md
@@ -1,0 +1,7 @@
+# System Drive Mapping
+
+```{toctree}
+:maxdepth: 99
+
+system-mounts
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System Drive Mapping/system-mounts.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System Drive Mapping/system-mounts.md
@@ -23,7 +23,7 @@ It's up to the user to ensure that the requested protocols are valid and support
 
 
 - Type: mount
-- Key: /system-mounts
+- Key: `/system-mounts`
 
 Note: 
  * Enabled: The value(s) referenced in the entry are applied on the client machine.
@@ -40,7 +40,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System Drive Mapping -> System mounts    |
-| Registry Key | Software\Policies\Ubuntu\mount\system-mounts         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System Drive Mapping -> System mounts`    |
+| Registry Key | `Software\Policies\Ubuntu\mount\system-mounts`         |
 | Element type | multiText |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/auto.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/auto.md
@@ -2,11 +2,11 @@
 
 Declare system-wide proxy auto-configuration URL.
 
-Auto-configuration URLs are always prioritized over manual proxy settings, meaning that if all proxy options are set, the GPO client will enable automatic proxy configuration for supported backends. An empty value will remove previously set settings of the same type.
+Auto-configuration URLs are always prioritised over manual proxy settings, meaning that if all proxy options are set, the GPO client will enable automatic proxy configuration for supported backends. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/auto
+- Key: `/proxy/auto`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -24,7 +24,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> Auto-configuration URL    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\auto         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> Auto-configuration URL`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\auto`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/ftp.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/ftp.md
@@ -2,13 +2,13 @@
 
 Declare system-wide HTTPS proxy setting. The value must be in the form of:
 
-  protocol://username:password@host:port
+  `protocol://username:password@host:port`
 
 It is not mandatory to escape special characters in the username or password. The GPO client will escape any unescaped special character before applying the proxy settings, and will take care not to double-escape already escaped characters. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/ftp
+- Key: `/proxy/ftp`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> FTP Proxy    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\ftp         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> FTP Proxy`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\ftp`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/http.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/http.md
@@ -2,13 +2,13 @@
 
 Declare system-wide HTTP proxy setting. The value must be in the form of:
 
-  protocol://username:password@host:port
+  `protocol://username:password@host:port`
 
 It is not mandatory to escape special characters in the username or password. The GPO client will escape any unescaped special character before applying the proxy settings, and will take care not to double-escape already escaped characters. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/http
+- Key: `/proxy/http`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> HTTP Proxy    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\http         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> HTTP Proxy`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\http`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/https.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/https.md
@@ -2,13 +2,13 @@
 
 Declare system-wide HTTPS proxy setting. The value must be in the form of:
 
-  protocol://username:password@host:port
+  `protocol://username:password@host:port`
 
 It is not mandatory to escape special characters in the username or password. The GPO client will escape any unescaped special character before applying the proxy settings, and will take care not to double-escape already escaped characters. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/https
+- Key: `/proxy/https`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> HTTPS Proxy    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\https         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> HTTPS Proxy`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\https`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/index.md
@@ -1,0 +1,12 @@
+# System proxy configuration
+
+```{toctree}
+:maxdepth: 99
+
+auto
+ftp
+http
+https
+no-proxy
+socks
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/no-proxy.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/no-proxy.md
@@ -2,13 +2,13 @@
 
 An array of hosts allowed to bypass the proxy settings. The host exclusion setting must be in the form of:
 
-localhost,127.0.0.1,::1
+`localhost,127.0.0.1,::1`
 
 Hosts can be individually wrapped in single (') or double quotes ("), or separated by spaces. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/no-proxy
+- Key: `/proxy/no-proxy`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> Ignored hosts    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\no-proxy         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> Ignored hosts`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\no-proxy`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/socks.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System proxy configuration/socks.md
@@ -2,13 +2,13 @@
 
 Declare system-wide HTTPS proxy setting. The value must be in the form of:
 
-  protocol://username:password@host:port
+  `protocol://username:password@host:port`
 
 It is not mandatory to escape special characters in the username or password. The GPO client will escape any unescaped special character before applying the proxy settings, and will take care not to double-escape already escaped characters. An empty value will remove previously set settings of the same type.
 
 
 - Type: proxy
-- Key: /proxy/socks
+- Key: `/proxy/socks`
 
 Note: -
  * Enabled: The setting in the text entry is applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> SOCKS Proxy    |
-| Registry Key | Software\Policies\Ubuntu\proxy\proxy\socks         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System proxy configuration -> SOCKS Proxy`    |
+| Registry Key | `Software\Policies\Ubuntu\proxy\proxy\socks`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System-wide application confinement/apparmor-machine.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System-wide application confinement/apparmor-machine.md
@@ -9,7 +9,7 @@ Profiles from this GPO will be appended to the list of profiles referenced highe
 
 
 - Type: apparmor
-- Key: /apparmor-machine
+- Key: `/apparmor-machine`
 
 Note: -
  * Enabled: The profiles in the text entry are applied on the client machine.
@@ -26,7 +26,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Client management -> System-wide application confinement -> AppArmor    |
-| Registry Key | Software\Policies\Ubuntu\apparmor\apparmor-machine         |
+| Location     | `Computer Policies -> Ubuntu -> Client management -> System-wide application confinement -> AppArmor`    |
+| Registry Key | `Software\Policies\Ubuntu\apparmor\apparmor-machine`         |
 | Element type | multiText |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/System-wide application confinement/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/System-wide application confinement/index.md
@@ -1,0 +1,7 @@
+# System-wide application confinement
+
+```{toctree}
+:maxdepth: 99
+
+apparmor-machine
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Client management/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Client management/index.md
@@ -1,0 +1,12 @@
+# Client management
+
+```{toctree}
+:maxdepth: 99
+
+Computer Scripts/index
+Power Management/index
+Privilege Authorisation/index
+System Drive Mapping/index
+System proxy configuration/index
+System-wide application confinement/index
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/allowed-failures.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/allowed-failures.md
@@ -3,7 +3,7 @@
 The number of times a user is allowed to attempt authentication, before giving up and going back to user selection.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/allowed-failures
+- Key: `/org/gnome/login-screen/allowed-failures`
 - Default: 3
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Number of allowed authentication failures    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\allowed-failures         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Number of allowed authentication failures`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\allowed-failures`         |
 | Element type | decimal |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-fingerprint-authentication.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-fingerprint-authentication.md
@@ -3,7 +3,7 @@
 The login screen can optionally allow users who have enrolled their fingerprints to log in using those prints.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/enable-fingerprint-authentication
+- Key: `/org/gnome/login-screen/enable-fingerprint-authentication`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow fingerprint readers for login    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-fingerprint-authentication         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow fingerprint readers for login`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-fingerprint-authentication`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-password-authentication.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-password-authentication.md
@@ -3,7 +3,7 @@
 The login screen can be configured to disallow password authentication, forcing the user to use smartcard or fingerprint authentication.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/enable-password-authentication
+- Key: `/org/gnome/login-screen/enable-password-authentication`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow passwords for login    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-password-authentication         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow passwords for login`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-password-authentication`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-smartcard-authentication.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/enable-smartcard-authentication.md
@@ -3,7 +3,7 @@
 The login screen can optionally allow users who have smartcards to log in using those smartcards.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/enable-smartcard-authentication
+- Key: `/org/gnome/login-screen/enable-smartcard-authentication`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow smartcard readers for login    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-smartcard-authentication         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Authentication -> Whether or not to allow smartcard readers for login`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\enable-smartcard-authentication`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Authentication/index.md
@@ -1,0 +1,10 @@
+# Authentication
+
+```{toctree}
+:maxdepth: 99
+
+allowed-failures
+enable-fingerprint-authentication
+enable-password-authentication
+enable-smartcard-authentication
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-color.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-color.md
@@ -1,12 +1,12 @@
-# The background-color property sets the background color.
+# The `background-color` property sets the background colour.
 
-The background-color property sets the background color to use when the background picture URI is missing or when it doesn't cover the whole background. It overrides the value defined in the default style sheet.
+The `background-color` property sets the background colour to use when the background picture URI is missing or when it doesn't cover the whole background. It overrides the value defined in the default style sheet.
 
 - Type: dconf
-- Key: /com/ubuntu/login-screen/background-color
+- Key: `/com/ubuntu/login-screen/background-color`
 - Default: ''
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> The background-color property sets the background color.    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-color         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> The background-color property sets the background color.`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-color`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-picture-uri.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-picture-uri.md
@@ -3,7 +3,7 @@
 URI to use for the background image. Note that the backend only supports local (file://) URIs. It overrides the value defined in the default style sheet.
 
 - Type: dconf
-- Key: /com/ubuntu/login-screen/background-picture-uri
+- Key: `/com/ubuntu/login-screen/background-picture-uri`
 - Default: ''
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Sets the background image for the login screen.    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-picture-uri         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Sets the background image for the login screen.`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-picture-uri`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-repeat.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-repeat.md
@@ -3,7 +3,7 @@
 The background-repeat property sets if/how a background image will be repeated. By default, a background-image is repeated both vertically and horizontally.  It overrides the value defined in the default style sheet.
 
 - Type: dconf
-- Key: /com/ubuntu/login-screen/background-repeat
+- Key: `/com/ubuntu/login-screen/background-repeat`
 - Default: 'default'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -25,7 +25,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> how the background image will be repeated.    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-repeat         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> how the background image will be repeated.`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-repeat`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-size.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/background-size.md
@@ -3,7 +3,7 @@
 The background-size property specifies the size of the background images.  There are three keywords you can use with this property: auto: The background image is displayed in its original size; cover: Resize the background image to cover the entire container, even if it has to stretch the image or cut a little bit off one of the edges; contain: Resize the background image to make sure the image is fully visible.  It overrides the value defined in the default style sheet.
 
 - Type: dconf
-- Key: /com/ubuntu/login-screen/background-size
+- Key: `/com/ubuntu/login-screen/background-size`
 - Default: 'default'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -22,7 +22,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> The background-size property specifies the size of the background image.    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-size         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> The background-size property specifies the size of the background image.`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\com\ubuntu\login-screen\background-size`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/banner-message-enable.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/banner-message-enable.md
@@ -3,7 +3,7 @@
 Set to true to show the banner message text.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/banner-message-enable
+- Key: `/org/gnome/login-screen/banner-message-enable`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Enable showing the banner message    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\banner-message-enable         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Enable showing the banner message`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\banner-message-enable`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/banner-message-text.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/banner-message-text.md
@@ -3,7 +3,7 @@
 Text banner message to show in the login window.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/banner-message-text
+- Key: `/org/gnome/login-screen/banner-message-text`
 - Default: ''
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Banner message text    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\banner-message-text         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Banner message text`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\banner-message-text`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-format.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-format.md
@@ -3,7 +3,7 @@
 Whether the clock displays in 24h or 12h format
 
 - Type: dconf
-- Key: /org/gnome/desktop/interface/clock-format
+- Key: `/org/gnome/desktop/interface/clock-format`
 - Default: '24h'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -20,7 +20,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Whether the clock displays in 24h or 12h format    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-format         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Whether the clock displays in 24h or 12h format`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-format`         |
 | Element type | dropdownList |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-show-date.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-show-date.md
@@ -3,7 +3,7 @@
 If true, display date in the clock, in addition to time.
 
 - Type: dconf
-- Key: /org/gnome/desktop/interface/clock-show-date
+- Key: `/org/gnome/desktop/interface/clock-show-date`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Show date in clock    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-show-date         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Show date in clock`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-show-date`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-show-weekday.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/clock-show-weekday.md
@@ -3,7 +3,7 @@
 If true, display weekday in the clock, in addition to time.
 
 - Type: dconf
-- Key: /org/gnome/desktop/interface/clock-show-weekday
+- Key: `/org/gnome/desktop/interface/clock-show-weekday`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Show weekday in clock    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-show-weekday         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Show weekday in clock`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\clock-show-weekday`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/index.md
@@ -1,0 +1,16 @@
+# Interface
+
+```{toctree}
+:maxdepth: 99
+
+background-color
+background-picture-uri
+background-repeat
+background-size
+banner-message-enable
+banner-message-text
+clock-format
+clock-show-date
+clock-show-weekday
+logo
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/logo.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/Interface/logo.md
@@ -3,7 +3,7 @@
 The login screen can optionally show a small image to provide site administrators and distributions a way to display branding.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/logo
+- Key: `/org/gnome/login-screen/logo`
 - Default: '/usr/share/plymouth/ubuntu-logo.png'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Interface -> Path to small image at top of user list    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\logo         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Interface -> Path to small image at top of user list`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\logo`         |
 | Element type | text |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/disable-restart-buttons.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/disable-restart-buttons.md
@@ -3,10 +3,10 @@
 Set to true to disable showing the restart buttons in the login window.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/disable-restart-buttons
+- Key: `/org/gnome/login-screen/disable-restart-buttons`
 - Default: false
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Disable showing the restart buttons    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\disable-restart-buttons         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Disable showing the restart buttons`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\disable-restart-buttons`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/disable-user-list.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/disable-user-list.md
@@ -3,7 +3,7 @@
 The login screen normally shows a list of available users to log in as. This setting can be toggled to disable showing the user list.
 
 - Type: dconf
-- Key: /org/gnome/login-screen/disable-user-list
+- Key: `/org/gnome/login-screen/disable-user-list`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Avoid showing user list    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\disable-user-list         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Avoid showing user list`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\login-screen\disable-user-list`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/index.md
@@ -1,0 +1,13 @@
+# Login Screen
+
+```{toctree}
+:maxdepth: 99
+
+Authentication/index
+disable-restart-buttons
+disable-user-list
+Interface/index
+show-banners
+show-in-lock-screen
+toolkit-accessibility
+```

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/show-banners.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/show-banners.md
@@ -3,7 +3,7 @@
 Whether notification banners are visible for application notifications.
 
 - Type: dconf
-- Key: /org/gnome/desktop/notifications/show-banners
+- Key: `/org/gnome/desktop/notifications/show-banners`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Show notification banners    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\notifications\show-banners         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Show notification banners`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\notifications\show-banners`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/show-in-lock-screen.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/show-in-lock-screen.md
@@ -3,7 +3,7 @@
 Whether notifications are shown in the lock screen or not.
 
 - Type: dconf
-- Key: /org/gnome/desktop/notifications/show-in-lock-screen
+- Key: `/org/gnome/desktop/notifications/show-in-lock-screen`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Show notifications in the lock screen    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\notifications\show-in-lock-screen         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Show notifications in the lock screen`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\notifications\show-in-lock-screen`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/toolkit-accessibility.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/Login Screen/toolkit-accessibility.md
@@ -3,7 +3,7 @@
 Whether toolkits should load accessibility related modules.
 
 - Type: dconf
-- Key: /org/gnome/desktop/interface/toolkit-accessibility
+- Key: `/org/gnome/desktop/interface/toolkit-accessibility`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | Computer Policies -> Ubuntu -> Login Screen -> Enable Toolkit Accessibility    |
-| Registry Key | Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\toolkit-accessibility         |
+| Location     | `Computer Policies -> Ubuntu -> Login Screen -> Enable Toolkit Accessibility`    |
+| Registry Key | `Software\Policies\Ubuntu\gdm\dconf\org\gnome\desktop\interface\toolkit-accessibility`         |
 | Element type | boolean |
 | Class:       | Machine       |

--- a/docs/reference/policies/Computer Policies/Ubuntu/index.md
+++ b/docs/reference/policies/Computer Policies/Ubuntu/index.md
@@ -1,0 +1,8 @@
+# Ubuntu
+
+```{toctree}
+:maxdepth: 99
+
+Client management/index
+Login Screen/index
+```

--- a/docs/reference/policies/Computer Policies/index.md
+++ b/docs/reference/policies/Computer Policies/index.md
@@ -1,0 +1,7 @@
+# Computer Policies
+
+```{toctree}
+:maxdepth: 99
+
+Ubuntu/index
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/index.md
@@ -1,0 +1,10 @@
+# Accessibility
+
+```{toctree}
+:maxdepth: 99
+
+screen-keyboard-enabled
+screen-magnifier-enabled
+screen-reader-enabled
+toolkit-accessibility
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-keyboard-enabled.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-keyboard-enabled.md
@@ -3,7 +3,7 @@
 Whether the on-screen keyboard is turned on.
 
 - Type: dconf
-- Key: /org/gnome/desktop/a11y/applications/screen-keyboard-enabled
+- Key: `/org/gnome/desktop/a11y/applications/screen-keyboard-enabled`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Accessibility -> On-screen keyboard    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-keyboard-enabled         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Accessibility -> On-screen keyboard`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-keyboard-enabled`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-magnifier-enabled.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-magnifier-enabled.md
@@ -3,7 +3,7 @@
 Whether the screen magnifier is turned on.
 
 - Type: dconf
-- Key: /org/gnome/desktop/a11y/applications/screen-magnifier-enabled
+- Key: `/org/gnome/desktop/a11y/applications/screen-magnifier-enabled`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Accessibility -> Screen magnifier    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-magnifier-enabled         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Accessibility -> Screen magnifier`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-magnifier-enabled`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-reader-enabled.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/screen-reader-enabled.md
@@ -3,7 +3,7 @@
 Whether the screen reader is turned on.
 
 - Type: dconf
-- Key: /org/gnome/desktop/a11y/applications/screen-reader-enabled
+- Key: `/org/gnome/desktop/a11y/applications/screen-reader-enabled`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Accessibility -> Screen reader    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-reader-enabled         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Accessibility -> Screen reader`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\a11y\applications\screen-reader-enabled`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/toolkit-accessibility.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Accessibility/toolkit-accessibility.md
@@ -3,7 +3,7 @@
 Whether toolkits should load accessibility related modules.
 
 - Type: dconf
-- Key: /org/gnome/desktop/interface/toolkit-accessibility
+- Key: `/org/gnome/desktop/interface/toolkit-accessibility`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Accessibility -> Enable Toolkit Accessibility    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\interface\toolkit-accessibility         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Accessibility -> Enable Toolkit Accessibility`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\interface\toolkit-accessibility`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/index.md
@@ -1,0 +1,9 @@
+# Background
+
+```{toctree}
+:maxdepth: 99
+
+picture-options
+picture-uri-dark
+picture-uri
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-options.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-options.md
@@ -1,31 +1,31 @@
 # Picture Options
 
-Determines how the image set by wallpaper_filename is rendered. Possible values are “none”, “wallpaper”, “centered”, “scaled”, “stretched”, “zoom”, “spanned”.
+Determines how the image set by wallpaper_filename is rendered. Possible values are `none`, `wallpaper`, `centered`, `scaled`, `stretched`, `zoom`, `spanned`.
 
 - Type: dconf
-- Key: /org/gnome/desktop/background/picture-options
-- Default: 'zoom'
+- Key: `/org/gnome/desktop/background/picture-options`
+- Default: `zoom`
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 <span style="font-size: larger;">**Valid values**</span>
 
-* none
-* wallpaper
-* centered
-* scaled
-* stretched
-* zoom
-* spanned
+* `none`
+* `wallpaper`
+* `centered`
+* `scaled`
+* `stretched`
+* `zoom`
+* `spanned`
 
 
 <span style="font-size: larger;">**Metadata**</span>
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Background -> Picture Options    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-options         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Background -> Picture Options`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-options`         |
 | Element type | dropdownList |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-uri-dark.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-uri-dark.md
@@ -3,7 +3,7 @@
 URI to use for the background image. Note that the backend only supports local (file://) URIs.
 
 - Type: dconf
-- Key: /org/gnome/desktop/background/picture-uri-dark
+- Key: `/org/gnome/desktop/background/picture-uri-dark`
 - Default for 22.04: 'file:///usr/share/backgrounds/warty-final-ubuntu.png'
 - Default for 24.04: 'file:///usr/share/backgrounds/ubuntu-wallpaper-d.png'
 - Default for 24.10: 'file:///usr/share/backgrounds/ubuntu-wallpaper-d.png'
@@ -18,7 +18,7 @@ Supported on Ubuntu 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Background -> Picture URI (dark)    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri-dark         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Background -> Picture URI (dark)`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri-dark`         |
 | Element type | text |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-uri.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Background/picture-uri.md
@@ -3,7 +3,7 @@
 URI to use for the background image. Note that the backend only supports local (file://) URIs.
 
 - Type: dconf
-- Key: /org/gnome/desktop/background/picture-uri
+- Key: `/org/gnome/desktop/background/picture-uri`
 - Default: 'file:///usr/share/backgrounds/warty-final-ubuntu.png'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Background -> Picture URI    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Background -> Picture URI`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\picture-uri`         |
 | Element type | text |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/control-center.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/control-center.md
@@ -3,7 +3,7 @@
 Binding to launch GNOME Settings.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/media-keys/control-center
+- Key: `/org/gnome/settings-daemon/plugins/media-keys/control-center`
 - Default: `['']`
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -17,6 +17,6 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 | Element      | Value            |
 | ---          | ---              |
 | Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Launch settings    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\media-keys\control-center         |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\media-keys\control-center`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/index.md
@@ -1,0 +1,12 @@
+# Keyboard shortcuts
+
+```{toctree}
+:maxdepth: 99
+
+control-center
+overlay-key
+panel-main-menu
+terminal
+toggle-application-view
+toggle-overview
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/overlay-key.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/overlay-key.md
@@ -3,7 +3,7 @@
 This key will initiate the “overlay”, which is a combination window overview and application launching system.  The default is intended to be the “Windows key” on PC hardware.  It’s expected that this binding either the default or set to the empty string.
 
 - Type: dconf
-- Key: /org/gnome/mutter/overlay-key
+- Key: `/org/gnome/mutter/overlay-key`
 - Default: 'Super_L'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Modifier to use for extended window management operations    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\mutter\overlay-key         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Modifier to use for extended window management operations`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\mutter\overlay-key`         |
 | Element type | text |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/panel-main-menu.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/panel-main-menu.md
@@ -1,7 +1,7 @@
 # Show the activities overview
 
 - Type: dconf
-- Key: /org/gnome/desktop/wm/keybindings/panel-main-menu
+- Key: `/org/gnome/desktop/wm/keybindings/panel-main-menu`
 - Default: `['<Alt>F1']`
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -14,7 +14,7 @@ Supported on Ubuntu 20.04.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Show the activities overview    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\wm\keybindings\panel-main-menu         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Show the activities overview`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\wm\keybindings\panel-main-menu`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/terminal.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/terminal.md
@@ -3,7 +3,7 @@
 Binding to launch the terminal.
 
 - Type: dconf
-- Key: /org/gnome/settings-daemon/plugins/media-keys/terminal
+- Key: `/org/gnome/settings-daemon/plugins/media-keys/terminal`
 - Default: `['<Primary><Alt>t']`
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Launch terminal    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\media-keys\terminal         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Launch terminal`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\settings-daemon\plugins\media-keys\terminal`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/toggle-application-view.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/toggle-application-view.md
@@ -3,7 +3,7 @@
 Keybinding to open the “Show Applications” view of the Activities Overview.
 
 - Type: dconf
-- Key: /org/gnome/shell/keybindings/toggle-application-view
+- Key: `/org/gnome/shell/keybindings/toggle-application-view`
 - Default: `["<Super>a"]`
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Keybinding to open the “Show Applications” view    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\shell\keybindings\toggle-application-view         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Keybinding to open the “Show Applications” view`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\shell\keybindings\toggle-application-view`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/toggle-overview.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Keyboard shortcuts/toggle-overview.md
@@ -3,7 +3,7 @@
 Keybinding to open the Activities Overview.
 
 - Type: dconf
-- Key: /org/gnome/shell/keybindings/toggle-overview
+- Key: `/org/gnome/shell/keybindings/toggle-overview`
 - Default for 20.04: `["<Super>s"]`
 - Default for 22.04: `["<Super>s"]`
 - Default for 24.04: `[]`
@@ -19,7 +19,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Keybinding to open the overview    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\shell\keybindings\toggle-overview         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Keyboard shortcuts -> Keybinding to open the overview`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\shell\keybindings\toggle-overview`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/disable-lock-screen.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/disable-lock-screen.md
@@ -3,7 +3,7 @@
 Prevent the user to lock his screen.
 
 - Type: dconf
-- Key: /org/gnome/desktop/lockdown/disable-lock-screen
+- Key: `/org/gnome/desktop/lockdown/disable-lock-screen`
 - Default: false
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Screensaver -> Disable lock screen    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\lockdown\disable-lock-screen         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Screensaver -> Disable lock screen`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\lockdown\disable-lock-screen`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/index.md
@@ -1,0 +1,10 @@
+# Screensaver
+
+```{toctree}
+:maxdepth: 99
+
+disable-lock-screen
+picture-options
+picture-uri
+show-in-lock-screen
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/picture-options.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/picture-options.md
@@ -1,31 +1,31 @@
 # Picture Options
 
-Determines how the image set by wallpaper_filename is rendered. Possible values are “none”, “wallpaper”, “centered”, “scaled”, “stretched”, “zoom”, “spanned”.
+Determines how the image set by wallpaper_filename is rendered. Possible values are `none`, `wallpaper`, `centered`, `scaled`, `stretched`, `zoom`, `spanned`.
 
 - Type: dconf
-- Key: /org/gnome/desktop/screensaver/picture-options
-- Default: 'zoom'
+- Key: `/org/gnome/desktop/screensaver/picture-options`
+- Default: `zoom`
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 <span style="font-size: larger;">**Valid values**</span>
 
-* none
-* wallpaper
-* centered
-* scaled
-* stretched
-* zoom
-* spanned
+* `none`
+* `wallpaper`
+* `centered`
+* `scaled`
+* `stretched`
+* `zoom`
+* `spanned`
 
 
 <span style="font-size: larger;">**Metadata**</span>
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Screensaver -> Picture Options    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\screensaver\picture-options         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Screensaver -> Picture Options`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\screensaver\picture-options`         |
 | Element type | dropdownList |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/picture-uri.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/picture-uri.md
@@ -3,7 +3,7 @@
 URI to use for the background image. Note that the backend only supports local (file://) URIs.
 
 - Type: dconf
-- Key: /org/gnome/desktop/screensaver/picture-uri
+- Key: `/org/gnome/desktop/screensaver/picture-uri`
 - Default: 'file:///usr/share/backgrounds/warty-final-ubuntu.png'
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Screensaver -> Picture URI    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\screensaver\picture-uri         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Screensaver -> Picture URI`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\screensaver\picture-uri`         |
 | Element type | text |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/show-in-lock-screen.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Screensaver/show-in-lock-screen.md
@@ -3,7 +3,7 @@
 Whether notifications are shown in the lock screen or not.
 
 - Type: dconf
-- Key: /org/gnome/desktop/notifications/show-in-lock-screen
+- Key: `/org/gnome/desktop/notifications/show-in-lock-screen`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Screensaver -> Show notifications in the lock screen    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\notifications\show-in-lock-screen         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Screensaver -> Show notifications in the lock screen`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\notifications\show-in-lock-screen`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/Clock/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/Clock/index.md
@@ -1,0 +1,9 @@
+# Clock
+
+```{toctree}
+:maxdepth: 99
+
+clock-format
+clock-show-date
+clock-show-weekday
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/LockDown/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/LockDown/index.md
@@ -1,0 +1,13 @@
+# LockDown
+
+```{toctree}
+:maxdepth: 99
+
+disable-command-line
+disable-log-out
+disable-printing
+disable-print-setup
+disable-save-to-disk
+disable-user-switching
+user-administration-disabled
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/Notifications/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/Notifications/index.md
@@ -1,0 +1,7 @@
+# Notifications
+
+```{toctree}
+:maxdepth: 99
+
+show-banners
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/favorite-apps.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/favorite-apps.md
@@ -1,9 +1,9 @@
-# List of desktop file IDs for favorite applications
+# List of desktop file IDs for favourite applications
 
-The applications corresponding to these identifiers will be displayed in the favorites area.
+The applications corresponding to these identifiers will be displayed in the `favorites` area.
 
 - Type: dconf
-- Key: /org/gnome/shell/favorite-apps
+- Key: `/org/gnome/shell/favorite-apps`
 - Default for 20.04: `[ 'ubiquity.desktop', 'firefox.desktop', 'thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'snap-store_ubuntu-software.desktop', 'yelp.desktop' ]`
 - Default for 22.04: `[ 'ubuntu-desktop-installer_ubuntu-desktop-installer.desktop', 'ubiquity.desktop', 'firefox_firefox.desktop', 'thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'snap-store_ubuntu-software.desktop', 'yelp.desktop' ]`
 - Default for 24.04: `[ 'ubuntu-desktop-bootstrap_ubuntu-desktop-bootstrap.desktop', 'firefox_firefox.desktop', 'thunderbird_thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'libreoffice-writer.desktop', 'snap-store_snap-store.desktop', 'yelp.desktop' ]`
@@ -19,7 +19,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Shell -> List of desktop file IDs for favorite applications    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\shell\favorite-apps         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Shell -> List of desktop file IDs for favorite applications`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\shell\favorite-apps`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/index.md
@@ -1,0 +1,12 @@
+# Shell
+
+```{toctree}
+:maxdepth: 99
+
+Clock/index
+favorite-apps
+LockDown/index
+Notifications/index
+show-desktop-icons
+show-show-apps-button
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/show-desktop-icons.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/show-desktop-icons.md
@@ -3,7 +3,7 @@
 If set to true, then file manager will draw the icons on the desktop.
 
 - Type: dconf
-- Key: /org/gnome/desktop/background/show-desktop-icons
+- Key: `/org/gnome/desktop/background/show-desktop-icons`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Shell -> Have file manager handle the desktop    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\show-desktop-icons         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Shell -> Have file manager handle the desktop`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\background\show-desktop-icons`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/show-show-apps-button.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/Shell/show-show-apps-button.md
@@ -3,7 +3,7 @@
 Show applications button in the dash
 
 - Type: dconf
-- Key: /org/gnome/shell/extensions/dash-to-dock/show-show-apps-button
+- Key: `/org/gnome/shell/extensions/dash-to-dock/show-show-apps-button`
 - Default: true
 
 Note: default system value is used for "Not Configured" and enforced if "Disabled".
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Desktop -> Shell -> Show applications button    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\shell\extensions\dash-to-dock\show-show-apps-button         |
+| Location     | `User Policies -> Ubuntu -> Desktop -> Shell -> Show applications button`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\shell\extensions\dash-to-dock\show-show-apps-button`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Desktop/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Desktop/index.md
@@ -1,0 +1,11 @@
+# Desktop
+
+```{toctree}
+:maxdepth: 99
+
+Accessibility/index
+Background/index
+Keyboard shortcuts/index
+Screensaver/index
+Shell/index
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Peripherals/automount.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Peripherals/automount.md
@@ -3,10 +3,10 @@
 If set to true, then Nautilus will automatically mount media such as user-visible hard disks and removable media on start-up and media insertion.
 
 - Type: dconf
-- Key: /org/gnome/desktop/media-handling/automount
+- Key: `/org/gnome/desktop/media-handling/automount`
 - Default: true
 
-Note: default system value is used for "Not Configured" and enforced if "Disabled".
+Note: default system value is used for `Not Configured` and enforced if `Disabled`.
 
 Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
@@ -16,7 +16,7 @@ Supported on Ubuntu 20.04, 22.04, 24.04, 24.10.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Peripherals -> Whether to automatically mount media    |
-| Registry Key | Software\Policies\Ubuntu\dconf\org\gnome\desktop\media-handling\automount         |
+| Location     | `User Policies -> Ubuntu -> Peripherals -> Whether to automatically mount media`    |
+| Registry Key | `Software\Policies\Ubuntu\dconf\org\gnome\desktop\media-handling\automount`         |
 | Element type | boolean |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Peripherals/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Peripherals/index.md
@@ -1,0 +1,7 @@
+# Peripherals
+
+```{toctree}
+:maxdepth: 99
+
+automount
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User Drive Mapping/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User Drive Mapping/index.md
@@ -1,0 +1,7 @@
+# User Drive Mapping
+
+```{toctree}
+:maxdepth: 99
+
+user-mounts
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User Drive Mapping/user-mounts.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User Drive Mapping/user-mounts.md
@@ -23,7 +23,7 @@ It's up to the user to ensure that the requested protocols are valid and support
 
 
 - Type: mount
-- Key: /user-mounts
+- Key: `/user-mounts`
 
 Note: 
  * Enabled: The value(s) referenced in the entry are applied on the client machine.
@@ -40,7 +40,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Session management -> User Drive Mapping -> User mounts    |
-| Registry Key | Software\Policies\Ubuntu\mount\user-mounts         |
+| Location     | `User Policies -> Ubuntu -> Session management -> User Drive Mapping -> User mounts`    |
+| Registry Key | `Software\Policies\Ubuntu\mount\user-mounts`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/index.md
@@ -1,0 +1,8 @@
+# User Scripts
+
+```{toctree}
+:maxdepth: 99
+
+logoff
+logon
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/logoff.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/logoff.md
@@ -6,7 +6,7 @@ Scripts from this GPO will be appended to the list of scripts referenced higher 
 
 
 - Type: scripts
-- Key: /logoff
+- Key: `/logoff`
 
 Note: -
  * Enabled: The scripts in the text entry are executed at user logoff time.
@@ -24,7 +24,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Session management -> User Scripts -> Logoff scripts    |
-| Registry Key | Software\Policies\Ubuntu\scripts\logoff         |
+| Location     | `User Policies -> Ubuntu -> Session management -> User Scripts -> Logoff scripts`    |
+| Registry Key | `Software\Policies\Ubuntu\scripts\logoff`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/logon.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User Scripts/logon.md
@@ -6,7 +6,7 @@ Scripts from this GPO will be appended to the list of scripts referenced higher 
 
 
 - Type: scripts
-- Key: /logon
+- Key: `/logon`
 
 Note: -
  * Enabled: The scripts in the text entry are executed at user logon time.
@@ -24,7 +24,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Session management -> User Scripts -> Logon scripts    |
-| Registry Key | Software\Policies\Ubuntu\scripts\logon         |
+| Location     | `User Policies -> Ubuntu -> Session management -> User Scripts -> Logon scripts`    |
+| Registry Key | `Software\Policies\Ubuntu\scripts\logon`         |
 | Element type | multiText |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User application confinement/apparmor-users.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User application confinement/apparmor-users.md
@@ -25,7 +25,7 @@ The configured profile will override any profile referenced higher in the GPO hi
 
 
 - Type: apparmor
-- Key: /apparmor-users
+- Key: `/apparmor-users`
 
 Note: -
  * Enabled: The profile in the text entry is applied on the client machine.
@@ -43,7 +43,7 @@ An Ubuntu Pro subscription on the client is required to apply this policy.
 
 | Element      | Value            |
 | ---          | ---              |
-| Location     | User Policies -> Ubuntu -> Session management -> User application confinement -> AppArmor    |
-| Registry Key | Software\Policies\Ubuntu\apparmor\apparmor-users         |
+| Location     | `User Policies -> Ubuntu -> Session management -> User application confinement -> AppArmor`    |
+| Registry Key | `Software\Policies\Ubuntu\apparmor\apparmor-users`         |
 | Element type | text |
 | Class:       | User       |

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/User application confinement/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/User application confinement/index.md
@@ -1,0 +1,7 @@
+# User application confinement
+
+```{toctree}
+:maxdepth: 99
+
+apparmor-users
+```

--- a/docs/reference/policies/User Policies/Ubuntu/Session management/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/Session management/index.md
@@ -1,0 +1,9 @@
+# Session management
+
+```{toctree}
+:maxdepth: 99
+
+User application confinement/index
+User Drive Mapping/index
+User Scripts/index
+```

--- a/docs/reference/policies/User Policies/Ubuntu/index.md
+++ b/docs/reference/policies/User Policies/Ubuntu/index.md
@@ -1,0 +1,9 @@
+# Ubuntu
+
+```{toctree}
+:maxdepth: 99
+
+Desktop/index
+Peripherals/index
+Session management/index
+```

--- a/docs/reference/policies/User Policies/index.md
+++ b/docs/reference/policies/User Policies/index.md
@@ -1,0 +1,7 @@
+# User Policies
+
+```{toctree}
+:maxdepth: 99
+
+Ubuntu/index
+```

--- a/docs/tutorial/certificates-autoenrollment.md
+++ b/docs/tutorial/certificates-autoenrollment.md
@@ -1,5 +1,0 @@
-# Certificates Auto-Enrollment
-
-[Certificate Auto-Enrollment](/explanation/certificates.md) is a key component of Ubuntu's Active Directory GPO support. This feature enables clients to seamlessly enroll for certificates from Active Directory Certificate Services. In this demonstration, we'll guide you through the entire process, starting from the initial setup requirements to configuring the Active Directory policy. This demonstration is designed to provide you with a hands-on understanding of how to efficiently implement and manage certificate auto-enrollment, ensuring your systems remain secure and compliant with organizational policies.
-
-[![Demo video](https://img.youtube.com/vi/RwVU7v0sEVY/hqdefault.jpg)](https://www.youtube.com/embed/RwVU7v0sEVY)

--- a/docs/tutorial/certificates-autoenrolment.md
+++ b/docs/tutorial/certificates-autoenrolment.md
@@ -1,0 +1,5 @@
+# Certificates Auto-Enrolment
+
+[Certificate Auto-Enrolment](/explanation/certificates.md) is a key component of Ubuntu's Active Directory GPO support. This feature enables clients to seamlessly enrol for certificates from Active Directory Certificate Services. In this demonstration, we'll guide you through the entire process, starting from the initial setup requirements to configuring the Active Directory policy. This demonstration is designed to provide you with a hands-on understanding of how to efficiently implement and manage certificate auto-enrolment, ensuring your systems remain secure and compliant with organisational policies.
+
+[![Demo video](https://img.youtube.com/vi/RwVU7v0sEVY/hqdefault.jpg)](https://www.youtube.com/embed/RwVU7v0sEVY)

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -4,11 +4,11 @@ This section contains step-by-step tutorials to help you get started with ADSys.
 
 ```{toctree}
 :hidden:
-certificates-autoenrollment
+certificates-autoenrolment
 ```
 
-## Certificates Auto-Enrollment
+## Certificates Auto-Enrolment
 
-Explore the essentials of Ubuntu's Certificate Auto-Enrollment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
+Explore the essentials of Ubuntu's Certificate Auto-Enrolment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
 
-* [Certificates auto-enrollment demo](certificates-autoenrollment.md)
+* [Certificates auto-enrolment demo](certificates-autoenrolment.md)


### PR DESCRIPTION
This changes the default spelling in the docs from US to GB.

Spelling was fixed in text elements, such as headers and paragraphs, but was not changed when a US-spelling referred to paths, keywords or GUI element that are defined in the code/app.

Where, for example, a path or keyword needed to include a US-spelling, it was surrounded in backticks to exclude it from the spellcheck. These changes were then applied to other similar elements for consistency, even when they did not contain US-spelling.

UDENG-3525