### PR TITLE
Ignore casing in domain/ section of sssd.conf

### DIFF
--- a/internal/ad/backends/sss/sss.go
+++ b/internal/ad/backends/sss/sss.go
@@ -48,7 +48,7 @@ func New(ctx context.Context, c Config, bus *dbus.Conn) (s SSS, err error) {
 		c.CacheDir = consts.DefaultSSSCacheDir
 	}
 
-	cfg, err := ini.Load(c.Conf)
+	cfg, err := ini.InsensitiveLoad(c.Conf)
 	if err != nil {
 		return SSS{}, err
 	}

--- a/internal/ad/backends/sss/sss_test.go
+++ b/internal/ad/backends/sss/sss_test.go
@@ -47,6 +47,7 @@ func TestSSSD(t *testing.T) {
 		"SSSd domain can not match ad domain":      {sssdConf: "domain-no-match-addomain"},
 		"Default domain suffix is read":            {sssdConf: "example.com-with-default-domain-suffix"},
 		"Use domain from section if no ad_domain":  {sssdConf: "example.com-without-ad_domain"},
+		"Ignore upper cases in domain name":        {sssdConf: "EXAMPLE.COM"},
 
 		// Special cases for config parameters
 		"Regular config, with cache dir": {sssdConf: "example.com", sssdCacheDir: "/some/specific/cachedir"},

--- a/internal/ad/backends/sss/testdata/TestSSSD/configs/EXAMPLE.COM
+++ b/internal/ad/backends/sss/testdata/TestSSSD/configs/EXAMPLE.COM
@@ -1,0 +1,5 @@
+[sssd]
+domains = example.com
+
+[domain/EXAMPLE.COM]
+ad_domain = example.com

--- a/internal/ad/backends/sss/testdata/TestSSSD/golden/ignore_upper_cases_in_domain_name
+++ b/internal/ad/backends/sss/testdata/TestSSSD/golden/ignore_upper_cases_in_domain_name
@@ -1,0 +1,9 @@
+* Domain(): example.com
+* ServerFQDN(): dynamic_active_server.example.com
+* IsOnline(): true
+* HostKrb5CCName(): /var/lib/sss/db/ccache_EXAMPLE.COM
+* DefaultDomainSuffix(): example.com
+* Config():
+Current backend is SSSD
+Configuration: testdata/TestSSSD/configs/EXAMPLE.COM
+Cache: /var/lib/sss/db


### PR DESCRIPTION
Use `ini.InsensitiveLoad` instead of `ini.Load` when reading `sssd.conf` to allow for both `domain/DOMAIN.COM` and `domain/domain.com` formatting.

Closes #1054 

UDENG-3725