### PR TITLE
Fix username parsing in PAM's slash_to_at_username

### DIFF
--- a/pam/pam_adsys.c
+++ b/pam/pam_adsys.c
@@ -264,7 +264,7 @@ static char *slash_to_at_username(const char *username) {
         char *ret = malloc((strlen(username) + 1) * sizeof(char));
         strcpy(ret, backslash + 1);
         strcat(ret, "@");
-        strncpy(ret + strlen(ret), username, backslash - username);
+        strncat(ret, username, backslash - username);
         return ret;
     }
     return strdup(username);


### PR DESCRIPTION
This function is supposed to transform a domain.com\user username to the @ format (i.e. user@domain.com). However, it was leaving the parsed username with bad characters in the end (maybe an off behavior from strncpy or something wrong in our string manipulation). Switching to `strncat` ensures we concatenate only what we want at the end of the string.

UDENG-4314