### PR TITLE
Fix version based tests on released version

### DIFF
--- a/cmd/adsysd/main_test.go
+++ b/cmd/adsysd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -128,6 +129,7 @@ func TestMainApp(t *testing.T) {
 	cmd.Env = append(os.Environ(), "ADSYS_CALL_MAIN=1")
 	out, err := cmd.CombinedOutput()
 
-	require.Contains(t, string(out), "adsysd\tdev", "Main function should print the version")
+	version := strings.TrimSpace(strings.TrimPrefix(string(out), "adsysd\t"))
+	require.NotEmpty(t, version, "Main function should print the version")
 	require.NoError(t, err, "Main should not return an error")
 }

--- a/cmd/adwatchd/main_test.go
+++ b/cmd/adwatchd/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -116,6 +117,7 @@ func TestMainApp(t *testing.T) {
 	cmd.Env = append(os.Environ(), "ADSYS_CALL_MAIN=1")
 	out, err := cmd.CombinedOutput()
 
-	require.Contains(t, string(out), "adwatchd\tdev", "Main function should print the version")
+	version := strings.TrimSpace(strings.TrimPrefix(string(out), "adwatchd\t"))
+	require.NotEmpty(t, version, "Main function should print the version")
 	require.NoError(t, err, "Main should not return an error")
 }


### PR DESCRIPTION
The release version has a real version number and not dev. Just ensure something is printed in the version string.