### PR TITLE
Add GPO list daemon timeout option

### DIFF
--- a/cmd/adsysd/daemon/daemon.go
+++ b/cmd/adsysd/daemon/daemon.go
@@ -51,9 +51,10 @@ type daemonConfig struct {
 	SystemUnitDir  string `mapstructure:"systemunit_dir"`
 	GlobalTrustDir string `mapstructure:"global_trust_dir"`
 
-	AdBackend     string         `mapstructure:"ad_backend"`
-	SSSdConfig    sss.Config     `mapstructure:"sssd"`
-	WinbindConfig winbind.Config `mapstructure:"winbind"`
+	AdBackend      string         `mapstructure:"ad_backend"`
+	SSSdConfig     sss.Config     `mapstructure:"sssd"`
+	WinbindConfig  winbind.Config `mapstructure:"winbind"`
+	GpoListTimeout int            `mapstructure:"gpo_list_timeout"`
 
 	ServiceTimeout int `mapstructure:"service_timeout"`
 }
@@ -125,6 +126,7 @@ func New() *App {
 				adsysservice.WithADBackend(a.config.AdBackend),
 				adsysservice.WithSSSConfig(a.config.SSSdConfig),
 				adsysservice.WithWinbindConfig(a.config.WinbindConfig),
+				adsysservice.WithGpoListTimeout(time.Second*time.Duration(a.config.GpoListTimeout)),
 			)
 			if err != nil {
 				close(a.ready)
@@ -161,6 +163,10 @@ func New() *App {
 
 	a.rootCmd.PersistentFlags().IntP("timeout", "t", consts.DefaultServiceTimeout, gotext.Get("time in seconds without activity before the service exists. 0 for no timeout."))
 	err = a.viper.BindPFlag("service_timeout", a.rootCmd.PersistentFlags().Lookup("timeout"))
+	decorate.LogOnError(&err)
+
+	a.rootCmd.PersistentFlags().IntP("gpo-list-timeout", "", consts.DefaultGpoListTimeout, gotext.Get("time in seconds for the gpo list. 0 for no timeout."))
+	err = a.viper.BindPFlag("gpo_list_timeout", a.rootCmd.PersistentFlags().Lookup("gpo-list-timeout"))
 	decorate.LogOnError(&err)
 
 	a.rootCmd.PersistentFlags().StringP("ad-backend", "", "sssd", gotext.Get("Active Directory authentication backend"))

--- a/cmd/adsysd/daemon/daemon.go
+++ b/cmd/adsysd/daemon/daemon.go
@@ -165,7 +165,7 @@ func New() *App {
 	err = a.viper.BindPFlag("service_timeout", a.rootCmd.PersistentFlags().Lookup("timeout"))
 	decorate.LogOnError(&err)
 
-	a.rootCmd.PersistentFlags().IntP("gpo-list-timeout", "", consts.DefaultGpoListTimeout, gotext.Get("time in seconds for the gpo list. 0 for no timeout."))
+	a.rootCmd.PersistentFlags().IntP("gpo-list-timeout", "", consts.DefaultGpoListTimeout, gotext.Get("time in seconds for the GPO list. 0 for no timeout."))
 	err = a.viper.BindPFlag("gpo_list_timeout", a.rootCmd.PersistentFlags().Lookup("gpo-list-timeout"))
 	decorate.LogOnError(&err)
 

--- a/conf.example/adsys.yaml
+++ b/conf.example/adsys.yaml
@@ -36,3 +36,6 @@ detect_cached_ticket: false
 
 # Client only configuration
 client_timeout: 60
+
+# GPO List timeout
+gpo_list_timeout: 30

--- a/conf.example/adsys.yaml
+++ b/conf.example/adsys.yaml
@@ -38,4 +38,4 @@ detect_cached_ticket: false
 client_timeout: 60
 
 # GPO List timeout
-gpo_list_timeout: 30
+gpo_list_timeout: 10

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -42,6 +42,7 @@ FQDN
 GDM
 gdm
 GPL
+gpo
 GPO
 gpolist
 GPOs

--- a/docs/reference/adsys-daemon.md
+++ b/docs/reference/adsys-daemon.md
@@ -177,6 +177,12 @@ A custom domain can be used to override the C API call that ADSys executes to de
 
 A custom domain controller can be used to override the C API call that ADSys executes to determine the AD controller FQDN -- which is returned by `wbinfo --dsgetdcname domain.com` (e.g. `adc.example.com`).
 
+### GPO configuration:
+
+* **gpo_list_timeout**
+
+Maximum time in seconds for the GPO list to finish otherwise the GPO list is aborted. This can be overridden by the `--gpo-list-timeout` option. Defaults to 10 seconds. 
+
 ### Client only configuration:**
 
 * **client_timeout**

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -254,7 +254,7 @@ func (ad *AD) GetPolicies(ctx context.Context, objectName string, objectClass Ob
 	args := append([]string{}, ad.gpoListCmd...) // Copy gpoListCmd to prevent data race
 	scriptArgs := []string{"--objectclass", string(objectClass), adServerFQDN, objectName}
 	cmdArgs := append(args, scriptArgs...)
-	cmdCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	cmdCtx, cancel := context.WithTimeout(ctx, ad.gpoListTimeout)
 	defer cancel()
 	log.Debugf(ctx, "Getting gpo list with arguments: %q", strings.Join(scriptArgs, " "))
 	// #nosec G204 - cmdArgs is under our control (python embedded script or mock for tests)

--- a/internal/adsysservice/adsysservice.go
+++ b/internal/adsysservice/adsysservice.go
@@ -71,6 +71,7 @@ type options struct {
 	systemUnitDir  string
 	globalTrustDir string
 	adBackend      string
+	gpoListTimeout time.Duration
 	sssConfig      sss.Config
 	winbindConfig  winbind.Config
 	authorizer     authorizerer
@@ -187,6 +188,14 @@ func WithWinbindConfig(c winbind.Config) func(o *options) error {
 	}
 }
 
+// WithGpoListTimeout specifies the timeout for the gpo list
+func WithGpoListTimeout(t time.Duration) func(o *options) error {
+	return func(o *options) error {
+		o.gpoListTimeout = t
+		return nil
+	}
+}
+
 // New returns a new instance of an AD service.
 // If url or domain is empty, we load the missing parameters from sssd.conf, taking first
 // domain in the list if not provided.
@@ -241,7 +250,8 @@ func New(ctx context.Context, opts ...option) (s *Service, err error) {
 	if args.runDir != "" {
 		adOptions = append(adOptions, ad.WithRunDir(args.runDir))
 	}
-	adOptions = append(adOptions, ad.WithGpoListTimeout(consts.DefaultGpoListTimeout))
+
+	adOptions = append(adOptions, ad.WithGpoListTimeout(args.gpoListTimeout))
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -2,8 +2,6 @@
 package consts
 
 import (
-	"time"
-
 	log "github.com/sirupsen/logrus"
 )
 
@@ -41,7 +39,7 @@ const (
 	DefaultServiceTimeout = 120
 
 	// DefaultGpoListTimeout is the default time to wait for the GPO list subcommand to finish.
-	DefaultGpoListTimeout = 10 * time.Second
+	DefaultGpoListTimeout = 10
 
 	// DistroID is the distro ID which can be overridden at build time.
 	DistroID = "Ubuntu"


### PR DESCRIPTION
Hello, I hope you are good.

Added a `--gpo-list-timeout` flag and a `gpo_list_timeout` configuration parameter on the adsys daemon.

By default, the GPO list timeout is fixed to 10 seconds. If the GPO list python script takes more than 10 seconds it's killed by the timeout. However, there might be scenarios where 10 seconds might not be enoguth. In our use case, the GPO list procedure finishes around 15 seconds in average. 

Have a wonderful day ^^