### PR TITLE
Fix minor linting issue

### DIFF
--- a/internal/adsysservice/adsysservice.go
+++ b/internal/adsysservice/adsysservice.go
@@ -188,7 +188,7 @@ func WithWinbindConfig(c winbind.Config) func(o *options) error {
 	}
 }
 
-// WithGpoListTimeout specifies the timeout for the gpo list
+// WithGpoListTimeout specifies the timeout for the gpo list.
 func WithGpoListTimeout(t time.Duration) func(o *options) error {
 	return func(o *options) error {
 		o.gpoListTimeout = t


### PR DESCRIPTION
As the CI couldn’t run on forked repo due to env variable capture, fix now this linting issue.