### PR TITLE
fix: Replace deprecated CI parameter

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage/codecov/Cobertura.xml
+          files: ./coverage/codecov/Cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   adwatchd-tests:


### PR DESCRIPTION
#1138 replaced the `file` parameter with `files`, so we need also to update it.