### PR TITLE
Sync Go versions declared in the project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/adsys
 
-go 1.22.0
+go 1.22.2
 
 toolchain go1.22.7
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/adsys/tools
 
-go 1.22.1
+go 1.22.2
 
 toolchain go1.23.0
 


### PR DESCRIPTION
We have a mismatch between the versions listed in the project root and the tools/ directory. Let's keep it synced.