### PR TITLE
Bump Go to 1.23

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
                dh-apport,
                dh-golang,
-               golang-go (>= 2:1.22~),
+               golang-go (>= 2:1.23~),
                apparmor,
                dbus,
                libdbus-1-dev,

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ubuntu/adsys
 
-go 1.22.2
+go 1.23.0
 
-toolchain go1.22.7
+toolchain go1.23.1
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/ubuntu/adsys/tools
 
-go 1.22.2
+go 1.23.0
 
-toolchain go1.23.0
+toolchain go1.23.1
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
We now rely on Go >= 1.22.7, but Jammy and Noble versions (for the `golang-1.22-go` package) only go up to 1.22.2, which means we would be unable to build for those distributions. Since those versions now also have `golang-1.23-go` available, let's use that package instead (this part of the change will only be noticeable on the SRUs) and bump the version here to ensure we are covered by our CI.