### PR TITLE
Fix integration test `TestDocCompletion`

### DIFF
--- a/cmd/adsysd/integration_tests/adsysctl_doc_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_doc_test.go
@@ -120,7 +120,8 @@ func TestDocCompletion(t *testing.T) {
 				if d.IsDir() ||
 					strings.HasPrefix(path, filepath.Join(docsDir, "reuse")) ||
 					strings.HasPrefix(path, docsDir+"/.") ||
-					strings.HasPrefix(path, filepath.Join(docsDir, "reference", "policies")) {
+					strings.HasPrefix(path, filepath.Join(docsDir, "reference", "policies")) ||
+					strings.HasPrefix(path, filepath.Join(docsDir, "diagrams")) {
 					return nil
 				}
 				if !strings.HasSuffix(d.Name(), ".md") {


### PR DESCRIPTION
PR #1177 introduced a new .md file in docs/diagrams. However, this file is a guide to how to use the diagram tooling rather than adsys documentation, so we need to ignore that directory as well in the test checks.