### PR TITLE
Bump Go toolchain version to 1.23.5

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,10 @@ export DH_GOLANG_INSTALL_ALL := 1
 # Tests needing sudo will be skipped automatically
 export ADSYS_SKIP_INTEGRATION_TESTS=1
 
+# We want to take whatever ubuntu propose to us (as it won’t download a newer version),
+# as long as it matches the go.mod go stenza which is the language requirement.
+export GOTOOLCHAIN := local
+
 %:
 	dh $@ --buildsystem=golang --with=golang,apport
 

--- a/e2e/scripts/patches/focal.patch
+++ b/e2e/scripts/patches/focal.patch
@@ -20,20 +20,22 @@ index ccf213e0..40a2aa9f 100644
                 dbus,
                 libdbus-1-dev,
 diff --git a/debian/rules b/debian/rules
-index 43646c6a..0708aa3d 100755
+index f9705a3d..3513e53f 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -25,6 +25,9 @@ export DH_GOLANG_INSTALL_ALL := 1
+@@ -25,9 +25,8 @@ export DH_GOLANG_INSTALL_ALL := 1
  # Tests needing sudo will be skipped automatically
  export ADSYS_SKIP_INTEGRATION_TESTS=1
 
+-# We want to take whatever ubuntu propose to us (as it won’t download a newer version),
+-# as long as it matches the go.mod go stenza which is the language requirement.
+-export GOTOOLCHAIN := local
 +# Run with Go 1.22
 +export PATH := /usr/lib/go-1.22/bin/:$(PATH)
-+
+
  %:
         dh $@ --buildsystem=golang --with=golang,apport
-
-@@ -83,3 +86,5 @@ endif
+@@ -87,3 +86,5 @@ endif
         ln -s adsysd debian/tmp/sbin/adsysctl
         # Run go generate to install assets, but don’t regenerate them
         GENERATE_ONLY_INSTALL_TO_DESTDIR=$(CURDIR)/debian/tmp go generate -x $(GOFLAGS),tools ./...

--- a/e2e/scripts/patches/jammy.patch
+++ b/e2e/scripts/patches/jammy.patch
@@ -12,21 +12,23 @@ index ccf213e0..2d34a328 100644
                 dbus,
                 libdbus-1-dev,
 diff --git a/debian/rules b/debian/rules
-index 43646c6a..403e7bb9 100755
+index f9705a3d..3bf891b4 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -25,9 +25,14 @@ export DH_GOLANG_INSTALL_ALL := 1
- # Tests needing sudo will be skipped automatically
- export ADSYS_SKIP_INTEGRATION_TESTS=1
+@@ -29,6 +29,9 @@ export ADSYS_SKIP_INTEGRATION_TESTS=1
+ # as long as it matches the go.mod go stenza which is the language requirement.
+ export GOTOOLCHAIN := local
 
 +# Run with Go 1.23
 +export PATH := /usr/lib/go-1.23/bin/:$(PATH)
 +
  %:
-	dh $@ --buildsystem=golang --with=golang,apport
+        dh $@ --buildsystem=golang --with=golang,apport
 
-+override_dh_dwz:
+@@ -87,3 +90,5 @@ endif
+        ln -s adsysd debian/tmp/sbin/adsysctl
+        # Run go generate to install assets, but don’t regenerate them
+        GENERATE_ONLY_INSTALL_TO_DESTDIR=$(CURDIR)/debian/tmp go generate -x $(GOFLAGS),tools ./...
 +
- override_dh_auto_clean:
- 	dh_auto_clean
- 	# Create the vendor directory when building the source package
++override_dh_dwz:
+

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.5
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys/tools
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.5
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
The crypto/x509 package has a vulnerability issue in Go 1.23.1, as can be seen in: https://github.com/ubuntu/adsys/actions/runs/13009232065.

To avoid it, we should bump the toolchain version.