### PR TITLE
docs: Change spelling to US

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -34,7 +34,6 @@ dialogs
 dir
 Dropdown
 dropdownList
-enrolment
 erroring
 executables
 fpath
@@ -72,6 +71,7 @@ linux
 localhost
 lockdown
 LockDown
+lockscreen
 LTS
 MacOS
 macOS
@@ -129,6 +129,8 @@ unescaped
 uri
 URI
 URIs
+usb
+USBGuard
 usr
 unticking
 vendoring

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -2,15 +2,15 @@ matrix:
 - name: rST files
   aspell:
     lang: en
-    d: en_GB
+    d: en_US
   dictionary:
     wordlists:
     - .wordlist.txt
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-      # check all docs except technical reference
-    - _build/**/*.html|!_build/reference/policies/**/*.html
+      # check all built docs
+    - _build/**/*.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -122,7 +122,9 @@ slug = ""
 # (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
-redirects = {}
+redirects = {
+    "tutorial/certificates-auto-enrolment": "../../tutorial/certificates-auto-enrollment",
+}
 
 ############################################################
 ### Link checker exceptions

--- a/docs/explanation/adsys-ref-arch.md
+++ b/docs/explanation/adsys-ref-arch.md
@@ -8,7 +8,7 @@ managing authentication and policies.
 ADSys is a GPO client. In an AD-managed infrastructure, it can help with the
 management and control of Ubuntu clients through the AD controller. It
 compliments and depends on SSSD, which is a daemon that handles authentication
-and provides authorisation to access remote directories, including AD. ADSys
+and provides authorization to access remote directories, including AD. ADSys
 can also be used in combination with Winbind, but here we will focus on SSSD.
 
 SSSD runs on the client Ubuntu machine and enables basic authentication with AD.
@@ -46,7 +46,7 @@ and SSSD is shown below:
 :align: center
 ```
 
-SSSD manages the enrolment and authentication of clients with AD. If ADSys is
+SSSD manages the enrollment and authentication of clients with AD. If ADSys is
 not installed, the control and management of AD clients stops at that point.
 
 If ADSys is installed, it checks whether GPOs on the client are up-to-date. If

--- a/docs/explanation/apparmor.md
+++ b/docs/explanation/apparmor.md
@@ -146,7 +146,7 @@ It is also recommended to define a `DEFAULT` subprofile as part of the system-wi
 }
 ```
 
-## Profile parsing behaviours
+## Profile parsing behaviors
 
 ### Troubleshooting misbehaving user profiles
 

--- a/docs/explanation/certificates.md
+++ b/docs/explanation/certificates.md
@@ -1,8 +1,8 @@
-# Certificate auto-enrolment
+# Certificate auto-enrollment
 
-The certificate policy manager allows clients to enrol for certificates from **Active Directory Certificate Services**. Certificates are then continuously monitored and refreshed by the [`certmonger`](https://www.freeipa.org/page/Certmonger) daemon. Currently, only machine certificates are supported.
+The certificate policy manager allows clients to enroll for certificates from **Active Directory Certificate Services**. Certificates are then continuously monitored and refreshed by the [`certmonger`](https://www.freeipa.org/page/Certmonger) daemon. Currently, only machine certificates are supported.
 
-Unlike the other ADSys policy managers which are configured in the special Ubuntu section provided by the ADMX files (Administrative Templates), settings for certificate auto-enrolment are configured in the Microsoft GPO tree:
+Unlike the other ADSys policy managers which are configured in the special Ubuntu section provided by the ADMX files (Administrative Templates), settings for certificate auto-enrollment are configured in the Microsoft GPO tree:
 
 * `Computer Configuration > Policies > Windows Settings > Security Settings > Public Key Policies > Certificate Services Client - Auto-Enrollment`
 
@@ -12,7 +12,7 @@ Unlike the other ADSys policy managers which are configured in the special Ubunt
 
 This feature is available only for subscribers of **Ubuntu Pro** and has been tested and known to work on all Ubuntu versions starting with 22.04 (Jammy).
 
-Additionally, the following packages must be installed on the client in order for auto-enrolment to work:
+Additionally, the following packages must be installed on the client in order for auto-enrollment to work:
 
 * [`certmonger`](https://www.freeipa.org/page/Certmonger) - daemon that monitors and updates certificates
 * [`cepces`](https://github.com/openSUSE/cepces) - `certmonger` extension that can communicate with **Active Directory Certificate Services**
@@ -31,11 +31,11 @@ On the Windows side, the following roles must be installed and configured:
 
 ## Rules precedence
 
-Auto-enrolment configuration will override any settings referenced higher in the GPO hierarchy.
+Auto-enrollment configuration will override any settings referenced higher in the GPO hierarchy.
 
 ## Policy configuration
 
-Certificate auto-enrolment is configured by setting the **Configuration Model** to **Enabled** and ticking the following checkbox: **Update certificates that use certificate templates**.
+Certificate auto-enrollment is configured by setting the **Configuration Model** to **Enabled** and ticking the following checkbox: **Update certificates that use certificate templates**.
 
 ![Certificate GPO properties](../images/explanation/certificates/certificate-gpo.png)
 
@@ -54,7 +54,7 @@ For more advanced configuration, a list of policy servers can be specified in th
 
 ## Applying the policy
 
-On the client system, a successful auto-enrolment will place certificate data in the following paths:
+On the client system, a successful auto-enrollment will place certificate data in the following paths:
 
 * `/var/lib/adsys/certs` - certificate data
 * `/var/lib/adsys/private/certs` - private key data
@@ -97,7 +97,7 @@ CA 'galacticcafe-CA':
 
 ## Policy implementation
 
-With the exception of policy parsing, ADSys leverages the Samba implementation of certificate auto-enrolment. As this feature is only available in newer versions of Samba, we have taken the liberty of vendoring the required Samba files to allow this policy to work on Ubuntu versions that ship an older Samba version. These files are shipped in `/usr/share/adsys/python/vendor_samba`.
+With the exception of policy parsing, ADSys leverages the Samba implementation of certificate auto-enrollment. As this feature is only available in newer versions of Samba, we have taken the liberty of vendoring the required Samba files to allow this policy to work on Ubuntu versions that ship an older Samba version. These files are shipped in `/usr/share/adsys/python/vendor_samba`.
 
 To ensure idempotency when applying the policy, we set up a Samba [TDB cache file](https://wiki.samba.org/index.php/TDB) at `/var/lib/adsys/samba/cert_gpo_state_$(hostname).tdb` which contains various information pertaining to the enrolled certificate(s).
 
@@ -136,7 +136,7 @@ Note that tampering with certificate data outside of ADSys (e.g. manually unmoni
 
 ### Debugging `auto-enroll` script
 
-While certificate parsing happens in ADSys itself, enrolment is done via an embedded Python helper script. For debugging purposes, it can be dumped to the current directory and made executable by executing the following commands:
+While certificate parsing happens in ADSys itself, enrollment is done via an embedded Python helper script. For debugging purposes, it can be dumped to the current directory and made executable by executing the following commands:
 
 ```output
 > adsysctl policy debug cert-autoenroll-script
@@ -172,4 +172,4 @@ While configuring Active Directory Certificate Services is outside the scope of 
 
 ## Acknowledgements
 
-We would like to thank the Samba team for making great strides in the research and implementation of certificate auto-enrolment via Active Directory Certificate Services.
+We would like to thank the Samba team for making great strides in the research and implementation of certificate auto-enrollment via Active Directory Certificate Services.

--- a/docs/explanation/dconf.md
+++ b/docs/explanation/dconf.md
@@ -6,7 +6,7 @@ Some settings are globally enforced on the machine while other are per-user spec
 
 ## Example of settings
 
-- Change the login screen layout and background colour.
+- Change the login screen layout and background color.
 - Set and lock the default applications in the launcher.
 - Set and lock the user wallpaper.
 - Set the date and time format of the clock.

--- a/docs/explanation/network-shares.md
+++ b/docs/explanation/network-shares.md
@@ -12,7 +12,7 @@ The mount process for these mounts is triggered at the moment a client logs in. 
 
 All protocols supported by the [mount command](https://manpages.ubuntu.com/manpages/jammy/en/man8/mount.8.html) should work out of the box. However, the only tested ones are `smb`, `ftp` and `nfs`.
 
-The backends for the protocols `smb` and `nfs` are automatically enabled when installing the adsys package. In order to enable the backend for `ftp` mounts, the user must install the recommended `curlftpfs` package. This behaviour is tested on Ubuntu and might differ on other Linux distributions.
+The backends for the protocols `smb` and `nfs` are automatically enabled when installing the adsys package. In order to enable the backend for `ftp` mounts, the user must install the recommended `curlftpfs` package. This behavior is tested on Ubuntu and might differ on other Linux distributions.
 
 Access control and file permissions should be configured on the shared location.
 
@@ -24,7 +24,7 @@ User mount policies are located under `Computer Configuration > Policies > Admin
 
 The form is a list of shared drives that should be mounted for the client machine. They must follow the structure `{protocol}://{host name or ip address}/{shared location}`.
 
-The default mount behaviour is to mount the listed shares anonymously. In order to require kerberos authentication for the mount process, the tag `[krb5]` can be added as a prefix to the listed share, i.e. `[krb5]{protocol}://{host name or ip address}/{shared location}`.
+The default mount behavior is to mount the listed shares anonymously. In order to require kerberos authentication for the mount process, the tag `[krb5]` can be added as a prefix to the listed share, i.e. `[krb5]{protocol}://{host name or ip address}/{shared location}`.
 
 Additional mount options are not supported yet.
 

--- a/docs/explanation/proxy.md
+++ b/docs/explanation/proxy.md
@@ -35,7 +35,7 @@ The `System proxy configuration` category provides a list of configurable proxy 
 
 ![HTTP proxy setting in GPO editor](../images/explanation/proxy/system-proxy-settings-focus.png)
 
-Configured settings will then be forwarded to `ubuntu-proxy-manager` which will apply them on all supported backends (e.g. environment variables, APT, GSettings). For an up-to-date list of supported backends, proxy formats and behaviours, refer to the ubuntu-proxy-manager [documentation](https://github.com/ubuntu/ubuntu-proxy-manager/blob/main/README.md).
+Configured settings will then be forwarded to `ubuntu-proxy-manager` which will apply them on all supported backends (e.g. environment variables, APT, GSettings). For an up-to-date list of supported backends, proxy formats and behaviors, refer to the ubuntu-proxy-manager [documentation](https://github.com/ubuntu/ubuntu-proxy-manager/blob/main/README.md).
 
 ### Disabling proxy settings
 

--- a/docs/explanation/scripts.md
+++ b/docs/explanation/scripts.md
@@ -55,7 +55,7 @@ The form is a list of scripts path, relative to the `scripts/` subdirectory of y
 
 This GPO won’t refer any scripts for execution.
 
-## Scripts behaviours
+## Scripts behaviors
 
 ### Scripts erroring out
 

--- a/docs/how-to/join-ad-manually.md
+++ b/docs/how-to/join-ad-manually.md
@@ -2,7 +2,7 @@
 
 ADSys supports two Active Directory backends:
 
-1. [SSSD](https://sssd.io/), or System Security Services Daemon, provides access to centralised identity management systems like Microsoft Active Directory, OpenLDAP, and various other directory servers. This client component retrieves and caches data from remote directory servers, delivering identity, authentication, and authorisation services to the host machine.
+1. [SSSD](https://sssd.io/), or System Security Services Daemon, provides access to centralized identity management systems like Microsoft Active Directory, OpenLDAP, and various other directory servers. This client component retrieves and caches data from remote directory servers, delivering identity, authentication, and authorization services to the host machine.
 2. [Winbind](https://wiki.samba.org/index.php/Configuring_Winbindd_on_a_Samba_AD_DC) is a component of the Samba suite that provides seamless integration and authentication services between UNIX or Linux systems and Windows-based networks, allowing the former to appear as members in a Windows Active Directory domain.
 
 ## Join manually using SSSD

--- a/docs/how-to/set-up-ad.md
+++ b/docs/how-to/set-up-ad.md
@@ -10,7 +10,7 @@ As a rule of thumb, we generally separate the Ubuntu configuration from the Wind
 
 ## Ubuntu administrative template generations
 
-**ADSys** ships with pre-built Active Directory administrative templates that you can install on your Active Directory server. You will find two flavours of them:
+**ADSys** ships with pre-built Active Directory administrative templates that you can install on your Active Directory server. You will find two flavors of them:
 
 * One listing only Long Term Supported (LTS) Ubuntu versions.
 * One listing all currently supported Ubuntu versions, including non LTS.

--- a/docs/how-to/set-up-adsys.md
+++ b/docs/how-to/set-up-adsys.md
@@ -39,11 +39,11 @@ Options such as the home directory path template, shell and others can be tweake
 
 ADSys relies on the configured AD backend (e.g. SSSD) to export the `KRB5CCNAME` environment variable pointing to a valid Kerberos ticket cache when a domain user performs authentication.
 
-If for any reason the backend doesn't export the variable but _does_ initialise a ticket cache in the [default path](https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name), ADSys can be configured to infer the path to the ticket cache (via the libkrb5 API) and export it as the `KRB5CCNAME` variable during both authentication and runs of `adsysctl update` for the current domain user.
+If for any reason the backend doesn't export the variable but _does_ initialize a ticket cache in the [default path](https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name), ADSys can be configured to infer the path to the ticket cache (via the libkrb5 API) and export it as the `KRB5CCNAME` variable during both authentication and runs of `adsysctl update` for the current domain user.
 
 To opt into this functionality, the following must be added to `/etc/adsys.yaml`:
 ```yaml
 detect_cached_ticket: true
 ```
 
-With this setting active, ADSys attempts to determine and export the path to the ticket cache. To avoid unexpected behaviours like rejecting authentication for non-domain users, no action is taken if the path returned by the libkrb5 API does not exist on disk.
+With this setting active, ADSys attempts to determine and export the path to the ticket cache. To avoid unexpected behaviors like rejecting authentication for non-domain users, no action is taken if the path returned by the libkrb5 API does not exist on disk.

--- a/docs/how-to/set-up-adwatchd.md
+++ b/docs/how-to/set-up-adwatchd.md
@@ -6,7 +6,7 @@ At its core, the program can be simplified to the following steps:
 
 - watch a list of user-configured directories for changes -- subdirectories are also watched, but only the root directory will have a `GPT.ini` file
 - when a change is detected, attempt to locate a `GPT.ini` file at the root of the watched directory, or create one if absent
-- if a `GPT.ini` file is found, increment the version stanza of the file by 1, thus signalling clients that a new version of the assets (including scripts) are available to download during the next client refresh
+- if a `GPT.ini` file is found, increment the version stanza of the file by 1, thus signaling clients that a new version of the assets (including scripts) are available to download during the next client refresh
 
 ## Installation
 
@@ -43,7 +43,7 @@ For a better understanding on what directories should be configured for watching
 
 Note that the interactive configuration tool can only be run if the `adwatchd` service is not already installed on the machine. Please refer to the [CLI usage](#CLI usage) section for instructions on how to finely manage the service.
 
-We recommend making use of the interactive configuration tool to install the application, as it provides a level of error handling, taking care of path normalisation and the creation of the configuration file.
+We recommend making use of the interactive configuration tool to install the application, as it provides a level of error handling, taking care of path normalization and the creation of the configuration file.
 
 The configuration file is stored as a YAML file, and can be freely edited after the application has been installed. The following keys are configurable:
 

--- a/docs/how-to/use-gpo.md
+++ b/docs/how-to/use-gpo.md
@@ -37,7 +37,7 @@ The change is now visible on the greeter.
 ### Modifying an user setting
 
 1. Let's create another GPO in `warthogs.biz > IT Dept > RnD`.
-1. Select the list of favourite desktop applications setting in `User Configuration > Policies > Administrative Templates > Ubuntu  > Desktop > Shell > List of desktop file IDs for favorite applications`.
+1. Select the list of favorite desktop applications setting in `User Configuration > Policies > Administrative Templates > Ubuntu  > Desktop > Shell > List of desktop file IDs for favorite applications`.
 1. Enter a list of valid .desktop file IDs, one per line, like the following:
 
 ```
@@ -103,7 +103,7 @@ The **right pane** of the GPO Management editor contains the general information
 
 #### Text entry
 
-The type `Text` represents a single line of text. If you don’t enclose a string with single quotes `'` and the value is not a decimal, it will be done automatically and the entry will be sanitised  (e.g. space, `'`…). If you want to force a decimal to be treated as a string, enclose the value with single quotes.
+The type `Text` represents a single line of text. If you don’t enclose a string with single quotes `'` and the value is not a decimal, it will be done automatically and the entry will be sanitized  (e.g. space, `'`…). If you want to force a decimal to be treated as a string, enclose the value with single quotes.
 
 The default value will be already set.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ ADSys enables system administrators to manage Ubuntu Desktop clients centrally v
 
 It simplifies the task of configuring Ubuntu systems in a Microsoft Active Directory environment. However, it doesn't handle user authentication or initial security policy, which are managed by SSSD/Winbind and PAM.
 
-ADSys is valuable for system administrators who wish to manage Ubuntu Desktop clients in a centralised manner through Microsoft Active Directory.
+ADSys is valuable for system administrators who wish to manage Ubuntu Desktop clients in a centralized manner through Microsoft Active Directory.
 
 ```{toctree}
 :hidden:

--- a/docs/reference/adsys-daemon.md
+++ b/docs/reference/adsys-daemon.md
@@ -89,7 +89,7 @@ The ADSys daemon is started on demand by systemd’s socket activation and only 
 
 ## Configuration
 
-`ADSys` doesn’t ship a configuration file by default. However, such a file can be created to modify the behaviour of the daemon and the client.
+`ADSys` doesn’t ship a configuration file by default. However, such a file can be created to modify the behavior of the daemon and the client.
 
 The configuration file can be system-wide in `/etc/adsys.yaml`. This will thus apply to both daemon and client. You can have per-user configuration by creating `$HOME/adsys.yaml`. It will then affect only the client for this user.
 
@@ -196,9 +196,9 @@ Only privileged users have access to this information. As with any other command
 
 More information is available in the [next chapter](adsysctl.md) covering adsysctl cat command.
 
-## Authorisations
+## Authorizations
 
-**ADSys** uses a privilege mechanism based on polkit to manage authorisations. Many commands require elevated privileges to be executed. If the adsys client is executed with insufficient privileges to execute a command, the user will be prompted to enter its password. If allowed then the command will be executed and denied otherwise.
+**ADSys** uses a privilege mechanism based on polkit to manage authorizations. Many commands require elevated privileges to be executed. If the adsys client is executed with insufficient privileges to execute a command, the user will be prompted to enter its password. If allowed then the command will be executed and denied otherwise.
 
 ![Polkit authentication dialog](../images/reference/adsys-daemon/daemon-polkit.png)
 

--- a/docs/reference/adsysctl.md
+++ b/docs/reference/adsysctl.md
@@ -2,7 +2,7 @@
 
 `adsysctl` is a command line utility to request actions from the daemon and query its current status. You can get more verbose output with the `-v` accumulative flags, which will stream all logs from the service corresponding to your specific request.
 
-As a general rule, favour shell completion and the help command for discovering various parts of the adsysctl user interface. It will help you by completing subcommands, flags, users and even chapters of the offline documentation!
+As a general rule, favor shell completion and the help command for discovering various parts of the adsysctl user interface. It will help you by completing subcommands, flags, users and even chapters of the offline documentation!
 
 ## Which policies are applied
 

--- a/docs/tutorial/certificates-auto-enrollment.md
+++ b/docs/tutorial/certificates-auto-enrollment.md
@@ -1,9 +1,9 @@
-# Certificates Auto-Enrolment
+# Certificates auto-enrollment
 
-Certificate Auto-Enrolment is a key component of Ubuntu’s Active Directory GPO support. 
-This feature enables clients to seamlessly enrol for certificates from Active Directory Certificate Services. 
+Certificate auto-enrollment is a key component of Ubuntu’s Active Directory GPO support. 
+This feature enables clients to seamlessly enroll for certificates from Active Directory Certificate Services. 
 
-This tutorial is designed to help you develop an understanding of how to efficiently implement and manage certificate auto-enrolment, ensuring your systems remain secure and compliant with organisational policies.
+This tutorial is designed to help you develop an understanding of how to efficiently implement and manage certificate auto-enrollment, ensuring your systems remain secure and compliant with organizational policies.
 
 A video version of the tutorial is also available:
 
@@ -17,7 +17,7 @@ A video version of the tutorial is also available:
 
 ## What you will do
 
-- Configure and update the auto-enrolment policy
+- Configure and update the auto-enrollment policy
 - Connect to a VPN server using certificates
 - Access resources on the virtual network
 
@@ -34,7 +34,7 @@ For the Windows Domain controller, refer to:
 
 - [Set up AD](../how-to/set-up-ad.md)
 
-## Configure the auto-enrolment policy
+## Configure the auto-enrollment policy
 
 First the policy needs to be configured.
 This is done through the same entry policy as that which is used to configure Windows clients.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,14 +1,14 @@
 # Tutorials
 
-This section contains step-by-step tutorials to help you get started with ADSys and learn about some its key features. 
+This section contains step-by-step tutorials to help you get started with ADSys and learn about some its key features.
 
 ```{toctree}
 :hidden:
-certificates-autoenrolment
+certificates-auto-enrollment
 ```
 
-## Certificates Auto-Enrolment
+## Certificates auto-enrollment
 
-Explore the essentials of Ubuntu's Certificate Auto-Enrolment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
+Explore the essentials of Ubuntu's certificate auto-enrollment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
 
-* [Certificates auto-enrolment](certificates-autoenrolment.md)
+* [Certificates auto-enrollment](certificates-auto-enrollment.md)


### PR DESCRIPTION
* Changes default spellchecker from UK to US in line with recent Canonical policy
* Fixes spellcheck errors from UK spellings and updates custom wordlist where needed
* Reactivates spellchecker on reference docs

UDENG-5698