### PR TITLE
docs: landing pages refresh

### DIFF
--- a/cmd/adsysd/integration_tests/adsysctl_doc_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_doc_test.go
@@ -22,8 +22,8 @@ func TestDocChapter(t *testing.T) {
 		wantInDoc string
 		wantErr   bool
 	}{
-		"Get documentation chapter":                     {chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
-		"Get documentation chapter with incorrect case": {chapter: "HoW-to-guIdes/set-Up-AD", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
+		"Get documentation chapter":                     {chapter: "how-to-guides/setting-up-active-directory", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
+		"Get documentation chapter with incorrect case": {chapter: "HoW-to-guIdes/setting-Up-Active-directory", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
 
 		// Section cases
 		"Section using alias":                  {chapter: "how-to-guides", wantInDoc: "# How-to guides"},
@@ -34,7 +34,7 @@ func TestDocChapter(t *testing.T) {
 		"Get main index with no parameter":         {wantInDoc: "# ADSys Documentation"},
 		"Get main index with index title doc name": {chapter: "adsys-documentation", wantInDoc: "# ADSys Documentation"},
 
-		"Get documentation is always authorized": {systemAnswer: "polkit_no", chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
+		"Get documentation is always authorized": {systemAnswer: "polkit_no", chapter: "how-to-guides/setting-up-active-directory", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
 
 		// Error cases
 		"Error on daemon not responding": {daemonNotStarted: true, wantErr: true},
@@ -137,7 +137,7 @@ func TestDocCompletion(t *testing.T) {
 			assert.Len(t, completions, wantNumDocs+2, "Should list all available documentation md files from docs/")
 
 			assert.Contains(t, completions, "how-to-guides", "contain a section index")
-			assert.Contains(t, completions, "how-to-guides/set-up-ad", "contain a section sub chapter with alias")
+			assert.Contains(t, completions, "how-to-guides/setting-up-active-directory", "contain a section sub chapter with alias")
 		})
 	}
 }

--- a/cmd/adsysd/integration_tests/adsysctl_doc_test.go
+++ b/cmd/adsysd/integration_tests/adsysctl_doc_test.go
@@ -22,8 +22,8 @@ func TestDocChapter(t *testing.T) {
 		wantInDoc string
 		wantErr   bool
 	}{
-		"Get documentation chapter":                     {chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory Server"},
-		"Get documentation chapter with incorrect case": {chapter: "HoW-to-guIdes/set-Up-AD", wantInDoc: "# How to set up the Active Directory Server"},
+		"Get documentation chapter":                     {chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
+		"Get documentation chapter with incorrect case": {chapter: "HoW-to-guIdes/set-Up-AD", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
 
 		// Section cases
 		"Section using alias":                  {chapter: "how-to-guides", wantInDoc: "# How-to guides"},
@@ -34,7 +34,7 @@ func TestDocChapter(t *testing.T) {
 		"Get main index with no parameter":         {wantInDoc: "# ADSys Documentation"},
 		"Get main index with index title doc name": {chapter: "adsys-documentation", wantInDoc: "# ADSys Documentation"},
 
-		"Get documentation is always authorized": {systemAnswer: "polkit_no", chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory Server"},
+		"Get documentation is always authorized": {systemAnswer: "polkit_no", chapter: "how-to-guides/set-up-ad", wantInDoc: "# How to set up the Active Directory server for Ubuntu clients"},
 
 		// Error cases
 		"Error on daemon not responding": {daemonNotStarted: true, wantErr: true},

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,6 +1,6 @@
 # Explanation
 
-**Discussion and clarification** of key topics.
+Discussions of key topics to aid your understanding of ADSys.
 
 ## Architecture
 
@@ -14,18 +14,16 @@ Architecture <adsys-ref-arch>
 ## Managers
 
 ADSys supports a wide variety of managers to configure and control various
-aspects of the client systems.
-
-Managers available with ADSys are:
+aspects of the client systems:
 
 ```{toctree}
 :titlesonly:
 GSettings <dconf>
-Privileges Management <privileges>
+Privileges management <privileges>
 scripts
-AppArmor Profiles <apparmor>
+AppArmor profiles <apparmor>
 network-shares
 proxy
-Certificates Auto-Enrollment <certificates>
-Security Policy <security-policy>
+certificates
+Security policy <security-policy>
 ```

--- a/docs/explanation/proxy.md
+++ b/docs/explanation/proxy.md
@@ -1,4 +1,4 @@
-# Network Proxy
+# Network proxy
 
 The proxy manager allows AD administrators to apply proxy settings on the clients. Currently, only system-wide proxy settings are supported.
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,34 +1,36 @@
 # How-to guides
 
-These guides accompany you through the complete ADSys operations lifecycle.
+These guides help you complete specific tasks across the ADSys operations
+lifecycle.
 
-## Installation
+## Windows domain controller
 
-### Windows Domain Controller
-
-This is the configuration needed on Windows Domain Controller.
+Installation and configuration guides for the Windows domain controller.
 
 ```{toctree}
 :titlesonly:
-Set up AD <set-up-ad>
-Set up adwatchd <set-up-adwatchd>
+Setting up Active Directory <set-up-ad>
+Setting up adwatchd <set-up-adwatchd>
 ```
 
-### Linux client machine
+## Ubuntu client machine
 
-This section outlines how to join your client machine to the domain, install ADSys, and verify that the setup is correct.
+Installation and configuration guides for the Ubuntu client machine.
 
 ```{toctree}
 :titlesonly:
-Join machine to AD during installation<join-ad-installation>
-Join machine to AD manually<join-ad-manually>
-Set up ADSys <set-up-adsys>
+Joining machine to Active Directory during installation<join-ad-installation>
+Joining machine to Active Directory manually<join-ad-manually>
+Setting up ADSys <set-up-adsys>
 ```
 
 ## Operations
 
+Create GPO rules in the domain controller and apply them to Ubuntu client
+machines.
+
 ```{toctree}
 :titlesonly:
 
-Use GPO with Ubuntu <use-gpo>
+Using GPO with Ubuntu <use-gpo>
 ```

--- a/docs/how-to/set-up-adsys.md
+++ b/docs/how-to/set-up-adsys.md
@@ -1,5 +1,15 @@
 # How to set up ADSys
 
+## Requirements
+
+ADSys is supported on Ubuntu starting from Ubuntu 20.04.2 LTS.
+
+It is tested with Windows Server 2019.
+
+Only Active Directory on-premise is supported.
+
+## Installation
+
 **ADSys** is not currently installed by default on Ubuntu desktop. This must be done manually by the local administrator of the machine.
 
 To do so, log in on first boot, update the repositories and install **ADSys**. On Ubuntu-based systems this can be accomplished with the following commands:

--- a/docs/how-to/set-up-adwatchd.md
+++ b/docs/how-to/set-up-adwatchd.md
@@ -1,4 +1,4 @@
-# Active Directory Watch Daemon
+# How to set up the Active Directory Watch Daemon
 
 The **Active Directory Watch Daemon** (or `adwatchd`) is a Windows application geared towards automating the manual process of incrementing the version stanza of a `GPT.ini` file.
 

--- a/docs/how-to/use-gpo.md
+++ b/docs/how-to/use-gpo.md
@@ -1,18 +1,20 @@
 # How to use GPO with Ubuntu
 
-As explained in previous chapter, there are 2 sets of Ubuntu specific settings in the **Group Policy Management Editor**:
+As explained in previous chapter, there are two sets of Ubuntu specific settings in the **Group Policy Management Editor**:
 
 * `[Policy Name] > Computer Configuration > Policies > Administrative Templates > Ubuntu` for the machine policies.
 * `[Policy Name] > User Configuration > Policies > Administrative Templates > Ubuntu` for the user policies.
 
 ## Your first Ubuntu GPO rule
 
-For this example we will use a test domain called `warthogs.biz` with 2 separate OUs.
+For this example we will use a test domain called `warthogs.biz` with two separate OUs.
 
 * The machine is called `adclient04` and belongs to `warthogs.biz > MainOffice`
+
 ![Main Office OU in Active Directory](../images/how-to/use-gpo/gpo_ou_computer.png)
 
 * The user is called `bob` and belongs to `warthogs.biz > IT Dept > RnD`
+
 ![IT Deps/RnD OU in Active Directory](../images/how-to/use-gpo/gpo_ou_user.png)
 
 In this example, we will demonstrate how to change dconf settings. We will first modify the greeter background image to illustrate how to enforce a computer setting and the list of preferred applications in the launcher for the user settings.
@@ -77,7 +79,7 @@ Next section will detail how to configure this and what happens when the Active 
 
 ### State of GPO settings
 
-Most GPO rules can have 3 states: `enabled`, `disabled`, `not configured`. These states may have different meanings depending on the manager.
+Most GPO rules can have three states: `enabled`, `disabled`, `not configured`. These states may have different meanings depending on the manager.
 
 ![States](../images/how-to/use-gpo/gpo_setting_states.png)
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -40,8 +40,3 @@ A comprehensive reference of policies supported by ADSys.
 policies/index
 ```
 
-## Supported releases
-
-**ADSys** is supported on Ubuntu starting from **20.04.2 LTS**, and tested with Windows Server 2019.
-
-Only Active Directory on-premise is supported.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,27 +1,26 @@
-# Technical Reference
+# Reference
 
-This section consolidates technical details on ADSys, including specifications, APIs, and architecture.
+Reference information is here provided for:
 
-On the Linux side, ADSys is composed of a daemon and a command line interface:
+* The daemon -- `adsysd` -- which implements the Group Policy protocol.
+* The command line interface -- `adsysctl` -- which controls the daemon and reports its status.
+* The Windows daemon -- `adwatchd` -- can be installed on the domain controller to
+automatically refresh assets without system administrator interventions.
 
-* The daemon - `adsysd` - implements the Group Policy protocol. It relies on Kerberos, Samba and LDAP for authentication and policy retrieval.
-* The command line interface - `adsysctl` - controls the daemon and reports its status.
+## Overview
 
-A Windows daemon, `adwatchd` can be installed on the domain controller to automatically refresh assets without system administrator interventions.
-
-````{grid} 1 1 2 2
-```{grid-item}
-## Reference
+Technical overview of the daemons and command line interface.
 
 ```{toctree}
 :titlesonly:
-ADSys Control (adsysctl)<adsysctl>
 ADSys Daemon (adsysd)<adsys-daemon>
+ADSys Control (adsysctl)<adsysctl>
 ADSys Watch Daemon (adwatchd)<adwatchd>
 ```
 
-```{grid-item}
-## Command line
+## Command line interface
+
+Description of commands for achieving specific actions in the terminal.
 
 ```{toctree}
 :titlesonly:
@@ -30,8 +29,9 @@ adsysd<adsysd-cli>
 adwatchd<adwatchd-cli>
 ```
 
-```{grid-item}
 ## Supported policies
+
+A comprehensive reference of policies supported by ADSys.
 
 ```{toctree}
 :titlesonly:
@@ -40,15 +40,8 @@ adwatchd<adwatchd-cli>
 policies/index
 ```
 
-````
-
 ## Supported releases
 
 **ADSys** is supported on Ubuntu starting from **20.04.2 LTS**, and tested with Windows Server 2019.
 
 Only Active Directory on-premise is supported.
-
-## Recommended readings
-
-* `adsysd help` or `man adsysd`.
-* `adsysctl help` or `man adsysctl`.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -9,6 +9,6 @@ certificates-auto-enrollment
 
 ## Certificates auto-enrollment
 
-Explore the essentials of Ubuntu's certificate auto-enrollment Feature, a crucial tool for seamless certificate management with Active Directory Certificate Services.
+Learn to use Ubuntu's certificate auto-enrollment feature for certificate management with Active Directory Certificate Services.
 
 * [Certificates auto-enrollment](certificates-auto-enrollment.md)


### PR DESCRIPTION
* makes landing pages more consistent within the ADSys docs and compared to other Canonical documentation sets
* generally, tried to reduce complexity on landing pages, by removing unnecessary content, improving styling and adding brief explanatory text where appropriate
* moved supported releases info from reference landing page (buried) into ADSys how-to guide (surfaced)
* other minor fixups: sentence case for titles and avoid numeric digits <10 in text, in accordance with our style guide, and some spacing adjustments
* failing test was addressed by updating titles in the Go test for docs

UDENG-6054