### PR TITLE
Bump toolchain to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
Fixes vulnerability #1: GO-2025-3563
   Request smuggling due to acceptance of invalid chunked data in net/http
More info: https://pkg.go.dev/vuln/GO-2025-3563