### PR TITLE
docs: build sitemap for ADSys docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,6 +169,24 @@ html_theme_options = {
 
 slug = "adsys"
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = "https://documentation.ubuntu.com/adsys/"
+
+# URL scheme. Add language and version scheme elements manually e.g. '{0}/{1}/{{link}}'.format(os.environ['READTHEDOCS_LANGUAGE'], os.environ['READTHEDOCS_VERSION'])
+
+# When configured with RTD variables, check for RTD environment so manual runs succeed:
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "stable/{link}"
+
 
 # Template and asset locations
 
@@ -253,6 +271,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.mermaid",
+    "sphinx_sitemap",
 ]
 
 # Excludes files or directories from processing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,6 +224,8 @@ linkcheck_ignore = [
     "http://127.0.0.1:8000",
     "https://leonelson.com/2011/08/15/how-to-increase-your-csr-key-size-on-microsoft-iis-without-removing-the-production-certificate/",
     "https://manpages.ubuntu.com/manpages/man8/*",
+    "https://www.samba.org/*",  # giving erroneous link failures as of June 16th 2025
+    "https://wiki.samba.org/*",  # giving erroneous link failures as of June 16th 2025
 ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ canonical-sphinx[full]
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinxcontrib.mermaid
+sphinx-sitemap


### PR DESCRIPTION
A sitemap improves search engine performance but is currently not available for the ADSys docs.

The changes in this PR generate a `sitemap.xml` when the docs site is built, e.g.,

![Screenshot from 2025-06-16 14-48-46](https://github.com/user-attachments/assets/7353c28f-27d5-4ac8-aa53-68b538040633)

It can be accessed at `https://documentation.ubuntu.com/adsys/{version}/sitemap.xml` after the PR is merged (note: won't be available in stable until next release).

It can also be previewed here: https://canonical-ubuntu-documentation-library--1263.com.readthedocs.build/adsys/1263/sitemap.xml

Similar changes are to be applied across all Canonical product documentation sites.

---

ps --- adding Samba docs to ignore list for linkcheck for now. The links work but are erroring, possibly due to request limits.

UDENG-7164