### PR TITLE
Bump Go toolchain to 1.23.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
Fixes Vulnerability #1: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.23.8
    Fixed in: os@go1.23.10
    Platforms: windows