### PR TITLE
ci: Avoid installing locales and man pages

### DIFF
--- a/.github/actions/azure-sstpc-vpn/action.yaml
+++ b/.github/actions/azure-sstpc-vpn/action.yaml
@@ -22,6 +22,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
     - name: Install required packages from PPA
       shell: bash
       run: |

--- a/.github/workflows/e2e-build-images.yaml
+++ b/.github/workflows/e2e-build-images.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix: ${{ steps.set-supported-releases.outputs.matrix }}
       versions: ${{ steps.set-supported-releases.outputs.versions }}
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install needed binaries
         run: |
           sudo apt-get update

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-supported-releases.outputs.matrix }}
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install needed binaries
         run: |
           sudo apt-get update
@@ -88,6 +89,7 @@ jobs:
       AD_PASSWORD: ${{ secrets.AD_PASSWORD }}
       ADSYS_PRO_TOKEN: ${{ secrets.ADSYS_PRO_TOKEN }}
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install required dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/policy-builds.yaml
+++ b/.github/workflows/policy-builds.yaml
@@ -38,6 +38,7 @@ jobs:
       matrix: ${{ steps.set-supported-releases.outputs.matrix }}
     needs: build-admxgen
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install needed binaries
         run: |
           sudo apt-get update
@@ -125,6 +126,7 @@ jobs:
       matrix:
         releases: ['LTS', 'ALL']
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install needed binaries
         run: |
           sudo apt-get update
@@ -168,6 +170,7 @@ jobs:
     runs-on: ${{ vars.RUNNER }}
     needs: collect-releases
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install needed binaries
         run: |
           sudo apt-get update

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -21,6 +21,7 @@ jobs:
     # workflow environements don’t work either.
     runs-on: ubuntu-24.04
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -52,6 +53,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
Speed up CI jobs by avoiding installation of locales and man pages.

The major performance gain that can be expected is that it makes the "Processing triggers for man-db" step a no-op. That step can otherwise take more than a minute, for example in [this recent run](https://github.com/ubuntu/adsys/actions/runs/17433469599/job/49497143068#step:4:420) it took 1m 20s:

<img width="784" height="39" alt="image" src="https://github.com/user-attachments/assets/bb39d74f-c6a8-422c-a720-32bde49363c4" />


UDENG-7865