### PR TITLE
docs: add release notes

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -108,6 +108,8 @@ rb
 readthedocs
 realmd
 runscripts
+schema
+schemas
 setgid
 setuid
 smartcard
@@ -150,6 +152,7 @@ usb
 USBGuard
 usr
 unticking
+vendored
 vendoring
 visudo
 VPN

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -52,10 +52,12 @@ glossary
 
 ## Features
 
-Overview of standard features and features enabled with a Pro subscription.
+Overview of ADSys' standard features and features enabled with a Pro
+subscription, in addition to release notes for ADSys.
 
 ```{toctree}
 :titlesonly:
 
 features
+release-notes
 ```

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -1,0 +1,68 @@
+(ref::release-notes)=
+# Release notes for ADSys
+
+This page includes release notes for recent version of ADSys.
+
+(ref::upgrade-instructions)=
+## Upgrade instructions for ADSys
+
+Ensure that you are using up-to-date packages:
+
+```{code-block} text
+sudo apt update && sudo apt upgrade -y
+```
+
+To check your version of ADSys, run:
+
+```{code-block} text
+adsysctl version
+```
+
+## Highlights from recent releases
+
+In this section, a major release is shown first, followed by its corresponding
+point releases from most recent to least recent.
+
+### ADSys 0.16.0
+
+* Add support for Polkit \>= 124
+* Make certificates auto enroll script run with debug enabled based on daemon verbosity
+* Refresh policy definition files
+
+#### Point releases for ADSys 0.16
+
+##### **ADSys 0.16.3**
+
+* Fix to vendored code for certificate auto-enrollment
+* Fix to the GPO parser
+* Add glossary to the documentation
+* Refresh documentation homepage and landing page
+
+##### **ADSys 0.16.2**
+
+Fixes and improvements to certificate autoenrollment:
+
+* Implement better log messages
+* Fix LDAP queries on multiple domain environments
+* Improve control over default behavior to get supported certificate templates
+
+##### **ADSys 0.16.1**
+
+* Add architecture diagrams to documentation
+
+```{dropdown} Older ADSys releases (expand to view)
+
+### ADSys 0.15
+
+#### 0.15.0
+
+* Fix DCONF policy manager removing the user database on empty policy
+* Ignore casing in domain/ section of `sssd.conf`
+* Fix parsing of slash usernames (e.g., domain\\user)
+* Fix `errno` in get_ticket_path()
+* Remove XML declaration from glib schemas
+
+#### 0.15.1
+
+No changes affecting user functionality.
+```


### PR DESCRIPTION
Adds release notes as a reference page to the documentation.

Notes include highlights from changelogs available on GitHub for recent releases.

This release notes page should be updated as future versions are released.

UDENG-8094