### PR TITLE
docs: move certs tutorial to howto section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,7 +208,11 @@ templates_path = [".sphinx/_templates"]
 #       the sphinx_reredirects extension will be disabled.
 
 redirects = {
-    "tutorial/certificates-auto-enrolment": "../../tutorial/certificates-auto-enrollment",
+    "tutorial/certificates-auto-enrolment": "../../how-to/certificates-auto-enrollment",
+    "tutorial/certificates-auto-enrollment": "../../how-to/certificates-auto-enrollment",
+    "tutorials/certificates-auto-enrolment": "../../how-to/certificates-auto-enrollment",
+    "tutorials/certificates-auto-enrollment": "../../how-to/certificates-auto-enrollment",
+    "how-to/certificates-auto-enrolment": "../../how-to/certificates-auto-enrollment",
 }
 
 

--- a/docs/how-to/certificates-auto-enrollment.md
+++ b/docs/how-to/certificates-auto-enrollment.md
@@ -1,4 +1,4 @@
-(tut::certificates)=
+(howto::certificates)=
 # Certificates auto-enrollment
 
 ```{include} ../pro_content_notice.txt
@@ -10,10 +10,6 @@ Certificate auto-enrollment is a key component of Ubuntu’s Active Directory GP
 This feature enables clients to seamlessly enroll for certificates from Active Directory Certificate Services.
 
 This tutorial is designed to help you develop an understanding of how to efficiently implement and manage certificate auto-enrollment, ensuring your systems remain secure and compliant with organizational policies.
-
-A video version of the tutorial is also available:
-
-[![Demo video](https://img.youtube.com/vi/RwVU7v0sEVY/hqdefault.jpg)](https://www.youtube.com/embed/RwVU7v0sEVY)
 
 ## What you need
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -33,4 +33,5 @@ machines.
 :titlesonly:
 
 Using GPO with Ubuntu <use-gpo>
+Using certificates auto-enrollment <certificates-auto-enrollment>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ explanation/index
 ````{grid} 1 1 2 2
 
 ```{grid-item-card}
-### [Tutorials](tutorial/index)
+### [Tutorial](tutorial/index)
 
 **Learn** to use ADSys for managing Ubuntu Desktop with Active Directory:
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -17,7 +17,7 @@ free for up to five machines.
 | AppArmor profiles                  | {bdg-danger}`No`   | {bdg-success}`Yes` | {ref}`exp::apparmor`				    |
 | Network shares                     | {bdg-danger}`No`   | {bdg-success}`Yes` | {ref}`exp::network-shares`   			    |
 | Network proxy                      | {bdg-danger}`No`   | {bdg-success}`Yes` | {ref}`exp::network-proxy`    			    |
-| Certificate auto-enrollment        | {bdg-danger}`No`   | {bdg-success}`Yes` | {ref}`tut::certificates`     			    |
+| Certificate auto-enrollment        | {bdg-danger}`No`   | {bdg-success}`Yes` | {ref}`howto::certificates`     			    |
 
 
 ```{tip}

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,23 +1,11 @@
-# Tutorials
-
-This section contains step-by-step tutorials to help you get started with ADSys and learn about some its key features.
+# Tutorial
 
 ```{toctree}
 :hidden:
 getting-started
-certificates-auto-enrollment
 ```
 
-## Getting started
-
-Set up Active Directory on Windows server and manage an Ubuntu client.
+Get started with ADSys by setting up Active Directory on Windows server, joining
+an Ubuntu client, and applying policies using ADSys
 
 * [Get started with ADSys](getting-started.md)
-
-## Certificates auto-enrollment
-
-<!-- TODO: this should be moved into the how-to section -->
-
-Learn to use Ubuntu's certificate auto-enrollment feature for certificate management with Active Directory Certificate Services.
-
-* [Certificates auto-enrollment](certificates-auto-enrollment.md)


### PR DESCRIPTION
We now have a dedicated getting started tutorial to act as the single entry point for new users of ADSys.

The tutorial on certificate auto-enrollment was always more of a how-to guide, so we should move it into the how-to section.

This PR also includes some minor changes for wording, links, and redirects.

UDENG-7607