### PR TITLE
Bump toolchain to 1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.23.0
 
-toolchain go1.23.10
+toolchain go1.23.12
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
Fixes Vulnerability `#1`: GO-2025-3956
    Unexpected paths returned from LookPath in os/exec
  More info: https://pkg.go.dev/vuln/GO-2025-3956
  Standard library
    Found in: os/exec@go1.23.10
    Fixed in: os/exec@go1.23.12