### PR TITLE
ci: Automatically cancel in-progress workflow runs on push

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -2,6 +2,10 @@ name: Check if CLA is signed
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cla-check:
     name: Check if CLA is signed

--- a/.github/workflows/e2e-build-images.yaml
+++ b/.github/workflows/e2e-build-images.yaml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '42 0 * * 0' # 00:42 UTC every Sunday
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   supported-releases:
     name: Build matrix for supported ADSys and Ubuntu releases

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,6 +22,10 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   supported-releases:
     name: Build matrix for supported ADSys and Ubuntu releases

--- a/.github/workflows/patch-vendored-samba.yaml
+++ b/.github/workflows/patch-vendored-samba.yaml
@@ -5,6 +5,10 @@ on:
     - cron: '0 9 * * 1' # run on a weekly cadence
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   checkout_files: |
     python/samba/gp/gp_cert_auto_enroll_ext.py

--- a/.github/workflows/policy-builds.yaml
+++ b/.github/workflows/policy-builds.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '42 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-admxgen:
     name: Build admxgen static binary

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -7,6 +7,10 @@ on:
       - "*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   apt_dependencies: >-
     ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -5,6 +5,10 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   apt_dependencies: >-
     ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev


### PR DESCRIPTION
The CI jobs run for a long time and use a lot of resources. If commits are pushed to the same PR in quick succession, the CI jobs run multiple times in parallel, even though older runs are usually not needed. This change saves some resources by automatically cancelling in-progress workflows on new pushes to the same branch.

The implementation is directly from the example of the concurrency keyword: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-concurrency-and-the-default-behavior