### PR TITLE
docs: fix quality badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Active Directory GPO support.
 
-[![Code quality](https://github.com/ubuntu/adsys/workflows/QA/badge.svg)](https://github.com/ubuntu/adsys/actions?query=workflow%3AQA)
+[![Code quality](https://github.com/ubuntu/adsys/actions/workflows/qa.yaml/badge.svg)](https://github.com/ubuntu/adsys/actions?query=workflow%3AQA)
 [![Code coverage](https://codecov.io/gh/ubuntu/adsys/branch/main/graph/badge.svg)](https://codecov.io/gh/ubuntu/adsys)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ubuntu/adsys.svg)](https://pkg.go.dev/github.com/ubuntu/adsys)
 [![Go Report Card](https://goreportcard.com/badge/ubuntu/adsys)](https://goreportcard.com/report/ubuntu/adsys)


### PR DESCRIPTION
Using syntax from working example (authd).

I think this works: [preview](https://github.com/ubuntu/adsys/blob/5a0b2e955fb19876d89770173ebdf85a099b37ed/README.md):

<img width="492" height="122" alt="image" src="https://github.com/user-attachments/assets/d95945dd-4f20-48e9-9ced-f030851297e0" />