### PR TITLE
docs: disable the edit link in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,9 +165,10 @@ if os.getenv("OPENAPI", ""):
 # - https://launchpad.net/example
 # - https://git.launchpad.net/example
 #
-html_theme_options = {
-    "source_edit_link": "https://github.com/ubuntu/adsys",
-}
+# NOTE: disabled for ADSys, as edit doesn't work for docs built from a tag (stable)
+# html_theme_options = {
+#     "source_edit_link": "https://github.com/ubuntu/adsys",
+# }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #


### PR DESCRIPTION
The edit link works when a docs version has a corresponding branch. 
In the ADSys docs, this is true for `latest` (branch=`main`) but not for `stable` (a tag, not a branch).

The edit behavior thus deviates depending on the docs version the user is reading.

For consistency, and as stable is the default version, we should disable the edit link until upstream (docs starter pack) finds a way to accommodate tags and mixed branch/tag workflows.