### PR TITLE
Properly disable Kerberos usage in AD tests

### DIFF
--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -181,6 +181,8 @@ func New(ctx context.Context, configBackend backends.Backend, hostname string, o
 		downloadables:  make(map[string]*downloadable),
 		gpoListCmd:     args.gpoListCmd,
 		gpoListTimeout: args.gpoListTimeout,
+
+		withoutKerberos: args.withoutKerberos,
 	}, nil
 }
 


### PR DESCRIPTION
We can't use Kerberos in the tests without a proper Kerberos server. However, we were not propagating the actual disablement to the code, which was resulting in Kerberos being enabled on all tests.

UDENG-9401