### PR TITLE
Bump Go to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ubuntu/adsys
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.10
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/adsys/tools
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
Go 1.24 has reached EOL three months ago. We need to bump the Go version of the project to keep up with the security fixes.