### PR TITLE
Bump Go toolchain to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
Fixes vulnerabilities:

Vulnerability 1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.25.10
    Fixed in: net/textproto@go1.25.11

Vulnerability 2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.25.10
    Fixed in: crypto/x509@go1.25.11