### PR TITLE
docs: fix sitemap var

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,11 +189,7 @@ html_baseurl = f"https://ubuntu.com/docs/adsys/{version}/"
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if "READTHEDOCS_VERSION" in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = "{version}{link}"
-else:
-    sitemap_url_scheme = "stable/{link}"
+sitemap_url_scheme = "{link}"
 
 # Include `lastmod` dates in the sitemap:
 


### PR DESCRIPTION
With the new config applied in https://github.com/ubuntu/adsys/pull/1402, there is a problem with the published sitemaps:

<img width="645" height="154" alt="Screenshot 2026-06-18 130651" src="https://github.com/user-attachments/assets/fe3dcd79-6bf0-40ed-846d-63b963a80086" />

This PR updates the sitemap scheme with a known fix, which works locally (where `local` stands-in for a version):

<img width="683" height="272" alt="Screenshot 2026-06-18 131042" src="https://github.com/user-attachments/assets/f73b837f-3f8b-4e8a-9093-62c419ac6be5" />

