### PR TITLE
AD: Query Global Catalog when fetching GPOs

### DIFF
--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/leonelquinteros/gotext"
+	"github.com/sirupsen/logrus"
 	"github.com/ubuntu/adsys/internal/ad/backends"
 	adcommon "github.com/ubuntu/adsys/internal/ad/common"
 	"github.com/ubuntu/adsys/internal/ad/registry"
@@ -266,6 +267,9 @@ func (ad *AD) GetPolicies(ctx context.Context, objectName string, objectClass Ob
 	// Otherwise, try fetching the GPO list from LDAP
 	args := append([]string{}, ad.gpoListCmd...) // Copy gpoListCmd to prevent data race
 	scriptArgs := []string{"--objectclass", string(objectClass), adServerFQDN, objectName}
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		scriptArgs = append(scriptArgs, "--debug")
+	}
 	cmdArgs := append(args, scriptArgs...)
 	cmdCtx, cancel := context.WithTimeout(ctx, ad.gpoListTimeout)
 	defer cancel()

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -48,6 +48,17 @@ const (
 	// policyServerPrefix is the GPO prefix containing keys that configure
 	// policy servers for certificate enrollment.
 	policyServersPrefix string = "Software/Policies/Microsoft/Cryptography/PolicyServers/"
+
+	// The following constants mirror the ReturnCode values returned by the
+	// adsys-gpolist script, so that distinct failures can be reported with
+	// actionable errors instead of an opaque non-zero exit code.
+
+	// gpoListNotFound is returned when the requested account can't be found in AD.
+	gpoListNotFound int = 1
+	// gpoListConnectionFailed is returned when the connection to the AD server failed.
+	gpoListConnectionFailed int = 2
+	// gpoListGPOFailed is returned when the GPO list couldn't be computed for the account.
+	gpoListGPOFailed int = 3
 )
 
 type gpo downloadable
@@ -270,7 +281,19 @@ func (ad *AD) GetPolicies(ctx context.Context, objectName string, objectClass Ob
 	err = cmd.Run()
 	smbsafe.DoneExec()
 	if err != nil {
-		return pols, errors.New(gotext.Get("failed to retrieve the list of GPO (exited with %d): %v\n%s", cmd.ProcessState.ExitCode(), err, stderr.String()))
+		exitCode := cmd.ProcessState.ExitCode()
+		var reason string
+		switch exitCode {
+		case gpoListNotFound:
+			reason = gotext.Get("account %q was not found in Active Directory", objectName)
+		case gpoListConnectionFailed:
+			reason = gotext.Get("could not connect to the Active Directory server %q", adServerFQDN)
+		case gpoListGPOFailed:
+			reason = gotext.Get("could not compute the GPO list for %q", objectName)
+		default:
+			reason = gotext.Get("unexpected error while retrieving the GPO list")
+		}
+		return pols, errors.New(gotext.Get("failed to retrieve the list of GPO: %s (exited with %d): %v\n%s", reason, exitCode, err, stderr.String()))
 	}
 
 	downloadables := make(map[string]string)

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/leonelquinteros/gotext"
@@ -162,6 +163,15 @@ func New(ctx context.Context, configBackend backends.Backend, hostname string, o
 		if err := o(&args); err != nil {
 			return nil, err
 		}
+	}
+
+	// Allow integration tests running the real daemon binary to disable
+	// kerberos authentication, as they have no real KDC to authenticate
+	// against. This is gated on testing.Testing() so it can only be
+	// triggered when running under `go test`, never in production.
+	if testing.Testing() && os.Getenv("ADSYS_TESTS_WITHOUT_KERBEROS") == "1" {
+		log.Warning(ctx, "Kerberos authentication disabled by ADSYS_TESTS_WITHOUT_KERBEROS=1 (test mode)")
+		args.withoutKerberos = true
 	}
 
 	krb5CacheDir := filepath.Join(args.runDir, "krb5cc")

--- a/internal/ad/ad.go
+++ b/internal/ad/ad.go
@@ -86,6 +86,9 @@ type AD struct {
 	krb5CacheDir     string
 
 	downloadables map[string]*downloadable
+	// downloadablesMu guards the downloadables map so that parsing, which only
+	// reads it, can run without holding the main AD lock.
+	downloadablesMu sync.RWMutex
 	sync.RWMutex
 	fetchMu sync.Mutex
 
@@ -326,25 +329,38 @@ func (ad *AD) GetPolicies(ctx context.Context, objectName string, objectClass Ob
 		return pols, err
 	}
 
+	// Fetching mutates the shared on-disk caches and the krb5cc tickets and,
+	// through libsmbclient, is serialized process-wide anyway, so run it under
+	// the AD lock. Release the lock right afterwards so the CPU-bound parsing
+	// below can overlap with other objects being refreshed (e.g. during
+	// `update --all`).
 	ad.Lock()
-	defer ad.Unlock()
 	assetsWereRefresh, err := ad.fetch(ctx, krb5CCPath, downloadables)
+	ad.Unlock()
 	if err != nil {
 		return pols, err
 	}
 
 	var errg errgroup.Group
-	// Parse policies
+	// Parse policies. This only reads the per-GPO caches (each guarded by its own
+	// downloadable mutex) and the downloadables map (guarded by downloadablesMu),
+	// so it runs without the AD lock and can proceed concurrently for several
+	// objects at once.
 	var gposRules []policies.GPO
 	errg.Go(func() (err error) {
 		gposRules, err = ad.parseGPOs(ctx, orderedGPOs, objectClass)
 		return err
 	})
 
-	// Compress assets
+	// Compress assets. The assets directory and its db are shared by every
+	// object, so serialize this behind the AD lock to exclude concurrent fetches
+	// and compressions.
 	var assetsDBPath string
 	assetsSrc := filepath.Join(ad.sysvolCacheDir, "assets")
 	errg.Go(func() (err error) {
+		ad.Lock()
+		defer ad.Unlock()
+
 		// Only compress assets if we have fetched them, otherwise attach optionally
 		// existing db.
 		if !assetsWereRefresh {
@@ -530,9 +546,13 @@ func (ad *AD) parseGPOs(ctx context.Context, gpos []gpo, objectClass ObjectClass
 }
 
 func (ad *AD) parseGPO(ctx context.Context, name, url, keyFilterPrefix string, objectClass ObjectClass, gpoWithRules policies.GPO) error {
-	ad.downloadables[name].mu.RLock()
-	defer ad.downloadables[name].mu.RUnlock()
-	_ = ad.downloadables[name].testConcurrent
+	ad.downloadablesMu.RLock()
+	d := ad.downloadables[name]
+	ad.downloadablesMu.RUnlock()
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_ = d.testConcurrent
 
 	log.Debugf(ctx, "Parsing GPO %q of class %q", name, objectClass)
 

--- a/internal/ad/ad_test.go
+++ b/internal/ad/ad_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -121,6 +122,7 @@ func TestGetPolicies(t *testing.T) {
 		want             policies.Policies
 		wantAssetsEquals string
 		wantErr          bool
+		wantErrContains  string
 	}{
 		"Standard policy, user object": {
 			gpoListArgs: []string{"gpoonly.com", "bob:standard"},
@@ -552,6 +554,23 @@ func TestGetPolicies(t *testing.T) {
 			gpoListArgs: []string{"gpoonly.com", "bob:bad-entry-type"},
 			wantErr:     true,
 		},
+
+		// The gpolist script exit codes are mapped to distinct, actionable errors.
+		"Error on account not found is reported distinctly": {
+			gpoListArgs:     []string{"-Exit1-"},
+			wantErr:         true,
+			wantErrContains: "was not found in Active Directory",
+		},
+		"Error on connection failure is reported distinctly": {
+			gpoListArgs:     []string{"-Exit2-"},
+			wantErr:         true,
+			wantErrContains: "could not connect to the Active Directory server",
+		},
+		"Error on GPO computation failure is reported distinctly": {
+			gpoListArgs:     []string{"-Exit3-"},
+			wantErr:         true,
+			wantErrContains: "could not compute the GPO list",
+		},
 		"Empty value for unfiltered entry": {
 			gpoListArgs: []string{"gpoonly.com", "bob:empty-value"},
 			wantErr:     true,
@@ -620,6 +639,9 @@ func TestGetPolicies(t *testing.T) {
 			entries, err := adc.GetPolicies(context.Background(), tc.objectName, tc.objectClass, krb5CCName)
 			if tc.wantErr {
 				require.Error(t, err, "GetPolicies should have errored out")
+				if tc.wantErrContains != "" {
+					require.ErrorContains(t, err, tc.wantErrContains, "GetPolicies returned an unexpected error")
+				}
 				return
 			}
 			require.NoError(t, err, "GetPolicies should return no error")
@@ -1346,10 +1368,16 @@ func TestMockGPOList(_ *testing.T) {
 		break
 	}
 
-	// simulating offline mode with Exit 2
-	if args[0] == "-Exit2-" {
-		fmt.Fprint(os.Stderr, "Error during gpo list requested with exit 2")
-		os.Exit(2)
+	// simulating script failures with a requested exit code, e.g. "-Exit2-"
+	// (also used to simulate offline mode).
+	if strings.HasPrefix(args[0], "-Exit") && strings.HasSuffix(args[0], "-") {
+		code, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(args[0], "-Exit"), "-"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid requested exit code %q", args[0])
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Error during gpo list requested with exit %d", code)
+		os.Exit(code)
 	}
 
 	// Get Domain

--- a/internal/ad/adsys-gpolist
+++ b/internal/ad/adsys-gpolist
@@ -45,6 +45,23 @@ class ReturnCode:
     GPO_FAILED = 3
 
 
+# Port of the Active Directory Global Catalog LDAP service. The Global Catalog
+# holds a partial replica of every object in the forest, which lets it expand a
+# user's complete group membership (universal and foreign-domain groups
+# included) without emitting LDAP referrals that Samba is unable to follow.
+GLOBAL_CATALOG_PORT = 3268
+
+# Well-known SIDs that the LSA injects when it builds a token (the default and
+# authenticated groups that user_session() used to add) but that are absent from
+# the tokenGroups attribute. We add them explicitly to the token we assemble
+# ourselves so the GPO access checks match what AD would compute: World covers
+# GPOs whose ACL grants read to "Everyone", Network marks the session as remote,
+# and Authenticated Users covers the most common GPO read ACE.
+SID_WORLD = "S-1-1-0"
+SID_NETWORK = "S-1-5-2"
+SID_AUTHENTICATED_USERS = "S-1-5-11"
+
+
 def parse_gplink(gplink):
     ''' Parse a gPLink into an array of dn and options '''
     ret = []
@@ -113,15 +130,23 @@ def get_entity(samdb, accountname, objectClass):
     return current.dn, str(ndr_unpack(security.dom_sid, current["objectSid"][0]))
 
 
-def get_all_groups(samdb, dn):
-    msg = samdb.search(expression='(&(objectClass=group)(member=%s))"' % ldb.binary_encode(str(dn)), attrs=['objectSid'])
+def get_group_sids(conn, dn):
+    ''' Returns the object's transitive set of group SIDs as seen by conn.
 
+    The tokenGroups constructed attribute is resolved against the given
+    connection. Against the Global Catalog it expands universal and
+    foreign-domain group membership across the whole forest but omits
+    domain-local groups; against a domain controller it additionally returns the
+    object's domain-local groups for its own domain. The caller unions both so
+    the token matches what AD would compute. A plain tokenGroups search never
+    emits the cross-domain LDAP referral that makes user_session() crash in a
+    multi-domain forest. '''
     sids = []
-
-    for m in msg:
-        sids.append(str(ndr_unpack(security.dom_sid, m["objectSid"][0])))
-    sids.append('AU')
-
+    for msg in conn.search(base=str(dn), scope=ldb.SCOPE_BASE, attrs=['tokenGroups']):
+        if 'tokenGroups' not in msg:
+            continue
+        for sid in msg['tokenGroups']:
+            sids.append(ndr_unpack(security.dom_sid, sid))
     return sids
 
 
@@ -151,14 +176,119 @@ def check_apply_gpo_right(secdesc, sids):
     return applied
 
 
+def build_token(user_sid, group_sids):
+    ''' Builds a security token from the user and group SIDs.
+
+    This is the fallback for samba.auth.user_session(), whose internal group
+    expansion fails in a multi-domain forest when the user belongs to a
+    universal or foreign-domain group: the domain controller answers with an
+    LDAP referral to the Global Catalog that Samba does not follow. Assembling
+    the token directly from the SIDs already resolved through the Global Catalog
+    avoids that code path entirely. It cannot reproduce everything user_session()
+    injects (primary group, owner/READ_CONTROL semantics), so it is only used
+    when user_session() actually raises. '''
+    token = security.token()
+    sids = ([security.dom_sid(user_sid)]
+            + list(group_sids)
+            + [security.dom_sid(s) for s in (SID_WORLD, SID_NETWORK, SID_AUTHENTICATED_USERS)])
+    token.sids = sids
+    # Real samba does NOT derive num_sids from the assigned list: the underlying
+    # security_token keeps its own count and samba.security.access_check() only
+    # iterates the first num_sids entries. Without setting it the token is seen
+    # as empty and every GPO read is denied -- which silently skips every GPO
+    # for any object that hits this fallback (e.g. multi-domain forest users
+    # whose user_session() raised). It must be set explicitly.
+    token.num_sids = len(sids)
+    return token
+
+
 def get_token(samdb, dn):
-    ''' Returns the security token for given samba and dn'''
+    ''' Returns the security token AD itself would build for the given DN.
+
+    samba.auth.user_session() assembles the same token the LSA computes at
+    logon: the primary group, the full transitive group membership, the default
+    well-known SIDs with their correct attributes, and the owner/READ_CONTROL
+    semantics a hand-built token cannot reproduce. It is the authoritative
+    source and matches what the domain controller grants, so we prefer it and
+    only fall back when it raises in a multi-domain forest. '''
     session_info_flags = (AUTH_SESSION_INFO_DEFAULT_GROUPS
                           | AUTH_SESSION_INFO_AUTHENTICATED
                           | AUTH_SESSION_INFO_SIMPLE_PRIVILEGES)
     session = user_session(samdb, lp_ctx=samdb.lp, dn=dn,
                            session_info_flags=session_info_flags)
     return session.security_token
+
+
+def get_primary_group_sid(samdb, dn, object_sid):
+    ''' Returns the object's primary group SID (Domain Computers / Domain Users).
+
+    tokenGroups omits the primary group, yet GPO security descriptors very
+    commonly grant read to it (a machine reads computer GPOs through Domain
+    Computers), so the tokenGroups fallback must add it back. The SID is the
+    object's domain SID -- its own SID with the last RID stripped -- combined
+    with the primaryGroupID RID. '''
+    msg = samdb.search(base=str(dn), scope=ldb.SCOPE_BASE, attrs=['primaryGroupID'])
+    raw = msg[0]['primaryGroupID'][0]
+    primary_group_id = int(raw.decode() if isinstance(raw, bytes) else raw)
+    domain_sid = str(object_sid).rsplit('-', 1)[0]
+    return security.dom_sid("%s-%d" % (domain_sid, primary_group_id))
+
+
+def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
+    ''' Assemble the security token from tokenGroups when user_session() fails.
+
+    Resolves group membership from two complementary sources and unions them:
+    the domain controller (which includes the object's domain-local groups) and
+    the Global Catalog (which expands universal and foreign-domain membership
+    forest-wide but omits domain-local groups). Returns (token, sids), or
+    (None, None) if neither source could be queried. '''
+    group_sids = {}
+    dc_failure = None
+    gc_failure = None
+
+    try:
+        dc_group_sids = get_group_sids(samdb, dn)
+        for sid in dc_group_sids:
+            group_sids[str(sid)] = sid
+    except Exception as exc:
+        dc_failure = exc
+
+    try:
+        gc = connectLDAP("ldap://%s:%d" % (fqdn, GLOBAL_CATALOG_PORT))
+        gc_group_sids = get_group_sids(gc, dn)
+        for sid in gc_group_sids:
+            group_sids[str(sid)] = sid
+    except Exception as exc:
+        # The Global Catalog is optional: the selected DC may not be a GC, or
+        # port 3268 may be blocked. We can still proceed with the domain
+        # controller's groups -- we just cannot expand cross-domain membership.
+        gc_failure = exc
+        print("WARNING: Global Catalog unreachable (%s); resolving group membership against the domain controller only. Cross-domain group membership is NOT expanded, so GPOs scoped to universal or foreign-domain groups may be skipped" % exc, file=sys.stderr)
+
+    # Only a total failure -- neither source could be queried -- is fatal. An
+    # object that legitimately belongs to no extra group yields an empty set,
+    # which is not an error.
+    if dc_failure is not None and gc_failure is not None:
+        print("Couldn't resolve the group membership for %s: the domain controller lookup failed (%s) and the Global Catalog lookup failed (%s)" % (accountname, dc_failure, gc_failure), file=sys.stderr)
+        return None, None
+
+    # tokenGroups omits the primary group (Domain Computers for a machine,
+    # Domain Users for a user), which GPO ACLs frequently grant read to. Add it
+    # explicitly so the fallback token matches what user_session() would build.
+    try:
+        primary_sid = get_primary_group_sid(samdb, dn, object_sid)
+        group_sids[str(primary_sid)] = primary_sid
+    except Exception:
+        pass
+
+    group_sids = list(group_sids.values())
+    try:
+        token = build_token(object_sid, group_sids)
+    except Exception as exc:
+        print("Couldn't build the security token for %s: %s" % (accountname, exc), file=sys.stderr)
+        return None, None
+
+    return token, [str(sid) for sid in group_sids]
 
 
 def get_gpos_for_dn(samdb, dn, token, sids, is_computer):
@@ -198,8 +328,15 @@ def get_gpos_for_dn(samdb, dn, token, sids, is_computer):
                                                 security.SEC_STD_READ_CONTROL
                                                 | security.SEC_ADS_LIST
                                                 | security.SEC_ADS_READ_PROP)
-                except RuntimeError:
-                    raise Exception("Failed access check on %s" % g['dn'])
+                except Exception:
+                    # The object's token is not granted read on this GPO. AD
+                    # silently skips GPOs it cannot read -- exactly like the
+                    # unreadable-descriptor case above -- so this must never
+                    # abort the whole refresh: otherwise a single hardened or
+                    # security-filtered GPO denies the machine every policy.
+                    print("Skipping GPO %s: the object has no read access to it" % g['dn'], file=sys.stderr)
+                    print(file=sys.stderr) # Empty line (no escaped EOL as we need to echo -E the script when using integration tests coverage)
+                    continue
 
                 if not check_apply_gpo_right(secdesc, sids):
                     continue
@@ -278,10 +415,29 @@ def main():
                 continue
             return ReturnCode.NOT_FOUND
 
-    sids = get_all_groups(samdb, dn)
-    sids.append(object_sid)
+    # Build the security token the same way AD itself does. user_session() is
+    # authoritative: it reproduces the primary group, the default well-known
+    # SIDs and the owner/READ_CONTROL semantics that a hand-assembled token
+    # cannot, so the GPO access checks match exactly what the domain controller
+    # grants. We use it whenever it succeeds.
+    #
+    # In a multi-domain forest it can fail: when the object belongs to a
+    # universal or foreign-domain group defined in another domain, the DC
+    # answers with an LDAP referral to the Global Catalog that Samba does not
+    # follow and user_session() raises (#1358, #1256). Only then do we fall back
+    # to assembling the token ourselves from the tokenGroups the domain
+    # controller and the Global Catalog report -- which never chase a referral.
+    try:
+        token = get_token(samdb, dn)
+        sids = [str(sid) for sid in token.sids]
+    except Exception as session_exc:
+        print("WARNING: user_session() could not build the token (%s); falling back to tokenGroups resolved from the domain controller and the Global Catalog" % session_exc, file=sys.stderr)
+        token, sids = build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname)
+        if token is None:
+            return ReturnCode.GPO_FAILED
 
-    token = get_token(samdb, dn)
+    sids.append(object_sid)
+    sids.extend(('WD', 'NW', 'AU'))
 
     try:
         gpos = get_gpos_for_dn(samdb, dn, token, sids, args.objectclass == ObjectClass.computer)

--- a/internal/ad/adsys-gpolist
+++ b/internal/ad/adsys-gpolist
@@ -234,7 +234,7 @@ def get_primary_group_sid(samdb, dn, object_sid):
     return security.dom_sid("%s-%d" % (domain_sid, primary_group_id))
 
 
-def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
+def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname, debug=False):
     ''' Assemble the security token from tokenGroups when user_session() fails.
 
     Resolves group membership from two complementary sources and unions them:
@@ -250,6 +250,8 @@ def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
         dc_group_sids = get_group_sids(samdb, dn)
         for sid in dc_group_sids:
             group_sids[str(sid)] = sid
+        if debug:
+            print("DEBUG: domain controller tokenGroups (%d): %s" % (len(dc_group_sids), ", ".join(str(s) for s in dc_group_sids)), file=sys.stderr)
     except Exception as exc:
         dc_failure = exc
 
@@ -258,6 +260,8 @@ def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
         gc_group_sids = get_group_sids(gc, dn)
         for sid in gc_group_sids:
             group_sids[str(sid)] = sid
+        if debug:
+            print("DEBUG: Global Catalog tokenGroups (%d): %s" % (len(gc_group_sids), ", ".join(str(s) for s in gc_group_sids)), file=sys.stderr)
     except Exception as exc:
         # The Global Catalog is optional: the selected DC may not be a GC, or
         # port 3268 may be blocked. We can still proceed with the domain
@@ -278,8 +282,11 @@ def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
     try:
         primary_sid = get_primary_group_sid(samdb, dn, object_sid)
         group_sids[str(primary_sid)] = primary_sid
-    except Exception:
-        pass
+        if debug:
+            print("DEBUG: primary group SID: %s" % primary_sid, file=sys.stderr)
+    except Exception as exc:
+        if debug:
+            print("DEBUG: could not resolve the primary group: %s" % exc, file=sys.stderr)
 
     group_sids = list(group_sids.values())
     try:
@@ -291,7 +298,7 @@ def build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname):
     return token, [str(sid) for sid in group_sids]
 
 
-def get_gpos_for_dn(samdb, dn, token, sids, is_computer):
+def get_gpos_for_dn(samdb, dn, token, sids, is_computer, debug=False):
     ''' List gpos for given dn, considering inheritance and enforced GPOs '''
     gpos = []
     inherit = True
@@ -322,6 +329,12 @@ def get_gpos_for_dn(samdb, dn, token, sids, is_computer):
                     print(file=sys.stderr) # Empty line (no escaped EOL as we need to echo -E the script when using integration tests coverage)
                     # GPOs that are unreadable are just skipped by AD
                     continue
+
+                if debug:
+                    try:
+                        print("DEBUG: security descriptor for %s: %s" % (g['dn'], secdesc.as_sddl()), file=sys.stderr)
+                    except Exception as sddl_exc:
+                        print("DEBUG: security descriptor for %s unavailable: %s" % (g['dn'], sddl_exc), file=sys.stderr)
 
                 try:
                     samba.security.access_check(secdesc, token,
@@ -375,6 +388,8 @@ def main():
     parser.add_argument('--objectclass', type=str,
                         choices=(ObjectClass.user, ObjectClass.computer), default=ObjectClass.user,
                         help='Class of the object to search for.')
+    parser.add_argument('--debug', action='store_true',
+                        help='Print the resolved security token and each GPO security descriptor to stderr to troubleshoot access checks.')
 
     args = parser.parse_args()
 
@@ -432,15 +447,24 @@ def main():
         sids = [str(sid) for sid in token.sids]
     except Exception as session_exc:
         print("WARNING: user_session() could not build the token (%s); falling back to tokenGroups resolved from the domain controller and the Global Catalog" % session_exc, file=sys.stderr)
-        token, sids = build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname)
+        token, sids = build_token_from_tokengroups(samdb, fqdn, dn, object_sid, accountname, args.debug)
         if token is None:
             return ReturnCode.GPO_FAILED
 
     sids.append(object_sid)
     sids.extend(('WD', 'NW', 'AU'))
 
+    if args.debug:
+        try:
+            token_sids = ", ".join(str(s) for s in token.sids)
+        except Exception as exc:
+            token_sids = "<unavailable: %s>" % exc
+        print("DEBUG: object SID: %s" % object_sid, file=sys.stderr)
+        print("DEBUG: access-check token SIDs: %s" % token_sids, file=sys.stderr)
+        print("DEBUG: apply-check SIDs: %s" % ", ".join(str(s) for s in sids), file=sys.stderr)
+
     try:
-        gpos = get_gpos_for_dn(samdb, dn, token, sids, args.objectclass == ObjectClass.computer)
+        gpos = get_gpos_for_dn(samdb, dn, token, sids, args.objectclass == ObjectClass.computer, debug=args.debug)
     except Exception as exc:
         print("Couldn't get GPOs: %s" % exc, file=sys.stderr)
         return ReturnCode.GPO_FAILED

--- a/internal/ad/adsys-gpolist_test.go
+++ b/internal/ad/adsys-gpolist_test.go
@@ -88,16 +88,64 @@ func TestAdsysGPOList(t *testing.T) {
 		"Security descriptor missing ignores GPO": { // AD is doing that for windows client
 			accountName: "RnDUserDep4@GPOONLY.COM",
 		},
-		"Fail on security descriptor access failure": {
-			accountName:    "RnDUserDep5@GPOONLY.COM",
-			wantReturnCode: 3,
-			wantErr:        true,
+		// An access check that errors out (rather than cleanly denying) still means
+		// the GPO is inaccessible, so AD skips it -- it must not abort the refresh.
+		"Security descriptor access failure ignores GPO": {
+			accountName: "RnDUserDep5@GPOONLY.COM",
 		},
 		"Security descriptor access denied ignores GPO": {
 			accountName: "RnDUserDep6@GPOONLY.COM",
 		},
 		"Security descriptor accepted is for another user": {
 			accountName: "RnDUserDep8@GPOONLY.COM",
+		},
+
+		// A universal group defined in the parent domain of the forest is only
+		// visible through the Global Catalog tokenGroups expansion. This is the
+		// multi-domain case that used to crash the script (issue #1358).
+		"Cross-domain universal group membership applies its GPO": {
+			accountName: "ChildUserWithParentGroup@GPOONLY.COM",
+		},
+
+		// A GPO scoped to a domain-local group applies only because the domain
+		// controller tokenGroups (which include domain-local membership) are
+		// unioned with the Global Catalog's. The Global Catalog alone omits
+		// domain-local groups, which used to deny the GPO and abort the refresh.
+		"Domain-local group membership applies its GPO": {
+			accountName: "UserWithDomainLocalGroup@GPOONLY.COM",
+		},
+
+		// The object's token grants no read on the GPO: AD skips it, so the
+		// script must skip it too instead of failing the whole refresh.
+		"Read access denied skips GPO": {
+			accountName: "UserReadDenied@GPOONLY.COM",
+		},
+
+		// user_session() raises in a multi-domain forest (the LDAP referral
+		// crash). The script must fall back to assembling the token from
+		// tokenGroups and still resolve the GPO, instead of aborting.
+		"Falls back to tokenGroups when user_session crashes": {
+			accountName: "UserSessionReferralFallback@GPOONLY.COM",
+		},
+
+		// The fallback must add the primary group (Domain Computers) that
+		// tokenGroups omits, otherwise a GPO scoped to it -- as computer GPOs
+		// commonly are -- would be wrongly skipped for child-domain objects.
+		"Fallback adds the primary group to the token": {
+			accountName: "UserPrimaryGroupFallback@GPOONLY.COM",
+		},
+
+		// Read and apply are scoped to World, granted only by the default
+		// well-known SIDs injected into the token. Regresses if build_token
+		// stops adding them (access check would deny every GPO read).
+		"Default token SIDs grant access to Everyone-scoped GPO": {
+			accountName: "UserEveryone@GPOONLY.COM",
+		},
+
+		// Wide read access must not imply application: World may read the GPO
+		// but is denied the apply right, so it must be filtered out.
+		"Everyone read access does not imply GPO application": {
+			accountName: "UserEveryoneDenied@GPOONLY.COM",
 		},
 
 		"No gPOptions fallbacks to 0": {

--- a/internal/ad/download.go
+++ b/internal/ad/download.go
@@ -90,19 +90,20 @@ func (ad *AD) fetch(ctx context.Context, krb5Ticket string, downloadables map[st
 
 	var errg errgroup.Group
 	for name, url := range downloadables {
+		// Guard the shared downloadables map: parsing reads it concurrently
+		// without holding the AD lock.
+		ad.downloadablesMu.Lock()
 		g, ok := ad.downloadables[name]
 		if !ok {
-			ad.downloadables[name] = &downloadable{
+			g = &downloadable{
 				name:     name,
 				url:      url,
 				mu:       &sync.RWMutex{},
-				isAssets: false,
+				isAssets: name == "assets",
 			}
-			if name == "assets" {
-				ad.downloadables[name].isAssets = true
-			}
-			g = ad.downloadables[name]
+			ad.downloadables[name] = g
 		}
+		ad.downloadablesMu.Unlock()
 		errg.Go(func() (err error) {
 			defer decorate.OnError(&err, gotext.Get("can't download %q", g.name))
 

--- a/internal/ad/download.go
+++ b/internal/ad/download.go
@@ -307,19 +307,7 @@ func downloadRecursive(ctx context.Context, client *libsmbclient.Client, url, de
 		switch dirent.Type {
 		case libsmbclient.SmbcFile:
 			log.Debug(ctx, gotext.Get("Downloading %s", entityURL))
-			f, err := client.Open(entityURL, 0, 0)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			// Read() is on *libsmbclient.File, not libsmbclient.File
-			pf := &f
-			data, err := io.ReadAll(pf)
-			if err != nil {
-				return err
-			}
-
-			if err := os.WriteFile(entityDest, data, 0600); err != nil {
+			if err := downloadFile(client, entityURL, entityDest); err != nil {
 				return err
 			}
 		case libsmbclient.SmbcDir:
@@ -329,6 +317,59 @@ func downloadRecursive(ctx context.Context, client *libsmbclient.Client, url, de
 			}
 		default:
 			return fmt.Errorf("unsupported type %q for entry %s", dirent.Type, dirent.Name)
+		}
+	}
+	return nil
+}
+
+// smbReadBufferSize is the buffer size used when streaming a file from SMB to
+// disk. libsmbclient serializes every operation on a process-global mutex and
+// each read maps to a network round-trip, so a large buffer keeps the number of
+// (globally serialized) reads to a minimum and lets libsmbclient fetch up to its
+// negotiated maximum read size per call. This is much faster than io.ReadAll,
+// whose small, growing buffer would issue many tiny reads per file.
+const smbReadBufferSize = 1024 * 1024
+
+// downloadFile streams a single SMB file to dest, using a large fixed buffer to
+// minimize the number of SMB read round-trips and to avoid holding the whole
+// file in memory.
+func downloadFile(client *libsmbclient.Client, url, dest string) (err error) {
+	defer decorate.OnError(&err, gotext.Get("download %q failed", url))
+
+	f, err := client.Open(url, 0, 0)
+	if err != nil {
+		return err
+	}
+	// Read() is on *libsmbclient.File, not libsmbclient.File
+	pf := &f
+	defer pf.Close()
+
+	dst, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := dst.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	// Copy manually with our own buffer rather than io.CopyBuffer: *os.File
+	// implements io.ReaderFrom, which would make io.CopyBuffer ignore our buffer
+	// and fall back to a small (32KiB) internal one.
+	buf := make([]byte, smbReadBufferSize)
+	for {
+		n, rerr := pf.Read(buf)
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if errors.Is(rerr, io.EOF) {
+			break
+		}
+		if rerr != nil {
+			return rerr
 		}
 	}
 	return nil

--- a/internal/ad/testdata/TestAdsysGPOList/golden/cross-domain_universal_group_membership_applies_its_gpo
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/cross-domain_universal_group_membership_applies_its_gpo
@@ -1,0 +1,2 @@
+CrossDomainGroup GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/CrossDomainGroup_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/default_token_sids_grant_access_to_everyone-scoped_gpo
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/default_token_sids_grant_access_to_everyone-scoped_gpo
@@ -1,0 +1,2 @@
+Everyone GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/Everyone_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/domain-local_group_membership_applies_its_gpo
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/domain-local_group_membership_applies_its_gpo
@@ -1,0 +1,2 @@
+DomainLocalGroup GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/DomainLocalGroup_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/everyone_read_access_does_not_imply_gpo_application
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/everyone_read_access_does_not_imply_gpo_application
@@ -1,0 +1,1 @@
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/fallback_adds_the_primary_group_to_the_token
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/fallback_adds_the_primary_group_to_the_token
@@ -1,0 +1,3 @@
+WARNING: user_session() could not build the token (user_session() failed: NT_STATUS_NOT_SUPPORTED (simulated multi-domain referral)); falling back to tokenGroups resolved from the domain controller and the Global Catalog
+PrimaryGroupFallback GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/PrimaryGroupFallback_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/falls_back_to_tokengroups_when_user_session_crashes
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/falls_back_to_tokengroups_when_user_session_crashes
@@ -1,0 +1,3 @@
+WARNING: user_session() could not build the token (user_session() failed: NT_STATUS_NOT_SUPPORTED (simulated multi-domain referral)); falling back to tokenGroups resolved from the domain controller and the Global Catalog
+SessionFallback GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/SessionFallback_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/read_access_denied_skips_gpo
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/read_access_denied_skips_gpo
@@ -1,0 +1,3 @@
+Skipping GPO ReadDenied_GPO: the object has no read access to it
+
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/ad/testdata/TestAdsysGPOList/golden/security_descriptor_access_failure_ignores_gpo
+++ b/internal/ad/testdata/TestAdsysGPOList/golden/security_descriptor_access_failure_ignores_gpo
@@ -1,0 +1,4 @@
+Skipping GPO RnDDep5_security_access_failed_GPO: the object has no read access to it
+
+RnD GPO	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/RnD_GPO
+Default Domain Policy	smb://adcontroller.example.com/SYSVOL/gpoonly.com/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}

--- a/internal/testutils/admock/ldb/__init__.py
+++ b/internal/testutils/admock/ldb/__init__.py
@@ -15,6 +15,30 @@ OUs = {}
 GPOs = {}
 accounts = {}
 
+# Group SIDs reported for an account by a tokenGroups query, split by the
+# directory service that answers it, because the two differ in real AD:
+#  * token_groups    -- the Global Catalog view: universal and global groups
+#    from across the forest, but never domain-local groups.
+#  * dc_token_groups -- the domain controller view for the account's own domain,
+#    which adds the domain-local groups the Global Catalog omits.
+# The script unions both, so a GPO scoped to a domain-local group still applies.
+# Accounts not listed fall back to a default, decorative Global Catalog set that
+# doesn't match any GPO security descriptor, and to no extra domain-local group.
+token_groups = {}
+dc_token_groups = {}
+DEFAULT_TOKEN_GROUPS = ["SidGroup1", "SidGroup2"]
+
+# Accounts (lowercased) for which the mocked user_session() raises, reproducing
+# the multi-domain referral crash so the script exercises its tokenGroups
+# fallback path.
+user_session_failures = set()
+
+
+def token_groups_for(name, is_global_catalog=True):
+    if is_global_catalog:
+        return token_groups.get(str(name).lower(), DEFAULT_TOKEN_GROUPS)
+    return dc_token_groups.get(str(name).lower(), [])
+
 ##############################
 # OU=RnD,OU=IT Dept,DC=domain,DC=com
 
@@ -119,8 +143,14 @@ class OU:
             gPLink += "[LDAP://%s;%d]" % (gpo.name, state)
         self.gPLink = [gPLink]
 
-    def addAccount(self, accountName):
+    def addAccount(self, accountName, token_groups_sids=None, dc_token_groups_sids=None, crash_user_session=False):
         Account(accountName, self)
+        if token_groups_sids is not None:
+            token_groups[accountName.lower()] = token_groups_sids
+        if dc_token_groups_sids is not None:
+            dc_token_groups[accountName.lower()] = dc_token_groups_sids
+        if crash_user_session:
+            user_session_failures.add(accountName.lower())
 
 
 class GPO:
@@ -153,6 +183,44 @@ class GPO:
             self.nTSecurityDescriptor = [self.nTSecurityDescriptor[0].replace("OA", "OD")]
         if name == "RnDDep8 allow for one user only GPO":
             self.nTSecurityDescriptor = [self.nTSecurityDescriptor[0].replace("S-1-5-21-16178157-162784614-155579044-1103", "OtherUserSid")]
+        if name == "CrossDomainGroup GPO":
+            # The "Apply Group Policy" right is granted to a universal group that
+            # lives in the parent domain of the forest. The user only gains it
+            # through the transitive membership the Global Catalog reports via
+            # tokenGroups, never through a direct, single-domain group search.
+            self.nTSecurityDescriptor = [self.nTSecurityDescriptor[0].replace("S-1-5-21-16178157-162784614-155579044-1103", "S-1-5-21-1111111111-2222222222-3333333333-512")]
+        if name == "Everyone GPO":
+            # Read and apply are granted only to World (Everyone). The user has
+            # it solely through the default well-known SIDs injected into the
+            # token, so this fails unless those SIDs are present.
+            self.nTSecurityDescriptor = ['O:S-1-5-21-16178157-162784614-155579044-512G:S-1-5-21-16178157-162784614-155579044-512D:PAI(OA;;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;WD)(A;CI;RPLCLORC;;;WD)']
+        if name == "Everyone read denied apply GPO":
+            # World is allowed read but explicitly denied the apply right. The
+            # broad token grants read, yet the deny ACE must keep the GPO from
+            # applying: wide read access must never imply application.
+            self.nTSecurityDescriptor = ['O:S-1-5-21-16178157-162784614-155579044-512G:S-1-5-21-16178157-162784614-155579044-512D:PAI(OD;;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;WD)(A;CI;RPLCLORC;;;WD)']
+        if name == "DomainLocalGroup GPO":
+            # Read and apply are granted only to a domain-local group of the
+            # object's own domain. The Global Catalog never reports domain-local
+            # membership through tokenGroups, so this GPO applies only because the
+            # domain controller's tokenGroups are unioned into the token.
+            self.nTSecurityDescriptor = ['O:S-1-5-21-16178157-162784614-155579044-512G:S-1-5-21-16178157-162784614-155579044-512D:PAI(OA;;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;S-1-5-21-16178157-162784614-155579044-1107)(A;CI;RPLCLORC;;;S-1-5-21-16178157-162784614-155579044-1107)']
+        if name == "ReadDenied GPO":
+            # Read and apply are granted only to a group the object is not a
+            # member of, so the read access check is denied. AD skips such GPOs,
+            # and so must the script instead of aborting the whole refresh.
+            self.nTSecurityDescriptor = ['O:S-1-5-21-16178157-162784614-155579044-512G:S-1-5-21-16178157-162784614-155579044-512D:PAI(OA;;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;S-1-5-21-16178157-162784614-155579044-1108)(A;CI;RPLCLORC;;;S-1-5-21-16178157-162784614-155579044-1108)']
+        if name == "SessionFallback GPO":
+            # Read and apply are granted to a group the object only gains through
+            # the Global Catalog tokenGroups expansion. user_session() raises for
+            # this account, so the GPO applies only via the tokenGroups fallback.
+            self.nTSecurityDescriptor = [self.nTSecurityDescriptor[0].replace("S-1-5-21-16178157-162784614-155579044-1103", "S-1-5-21-1111111111-2222222222-3333333333-512")]
+        if name == "PrimaryGroupFallback GPO":
+            # Read and apply are granted only to the primary group (Domain
+            # Computers, RID 515), which tokenGroups omits. user_session() raises
+            # for this account, so the GPO applies only if the fallback adds the
+            # primary group back to the token.
+            self.nTSecurityDescriptor = ['O:S-1-5-21-16178157-162784614-155579044-512G:S-1-5-21-16178157-162784614-155579044-512D:PAI(OA;;CR;edacfd8f-ffb3-11d1-b41d-00a0c968f939;;S-1-5-21-16178157-162784614-155579044-515)(A;CI;RPLCLORC;;;S-1-5-21-16178157-162784614-155579044-515)']
 
         smb_port = getenv("ADSYS_TESTS_SMB_PORT")
         if smb_port:
@@ -266,6 +334,55 @@ o.addAccount("UserNogPOptions")
 
 o = OU("/example/InvalidGPOLink")
 o.addAccount("UserInvalidLink")
+
+# Cross-domain membership: the GPO applies only because the Global Catalog
+# reports, through tokenGroups, a universal group from the forest parent domain.
+o = OU("/example/CrossDomainGroup")
+o.addGPO(GPO("CrossDomainGroup GPO"))
+o.addAccount("ChildUserWithParentGroup", token_groups_sids=["S-1-5-21-1111111111-2222222222-3333333333-512"])
+
+# Everyone-scoped GPO: read and apply are granted only to World, which the user
+# obtains exclusively from the default well-known SIDs added to the token. It
+# regresses if build_token stops injecting them (#1421 access-check failure).
+o = OU("/example/Everyone")
+o.addGPO(GPO("Everyone GPO"))
+o.addAccount("UserEveryone", token_groups_sids=[])
+
+# Everyone is allowed read but denied the apply right: a broad token must read
+# the GPO yet never apply it, guarding against read access implying application.
+o = OU("/example/EveryoneDenied")
+o.addGPO(GPO("Everyone read denied apply GPO"))
+o.addAccount("UserEveryoneDenied", token_groups_sids=[])
+
+# Domain-local group membership: the GPO is scoped to a domain-local group that
+# only the domain controller's tokenGroups report. The Global Catalog omits it,
+# so the GPO applies only because the DC tokenGroups are unioned into the token.
+o = OU("/example/DomainLocalGroup")
+o.addGPO(GPO("DomainLocalGroup GPO"))
+o.addAccount("UserWithDomainLocalGroup", token_groups_sids=[], dc_token_groups_sids=["S-1-5-21-16178157-162784614-155579044-1107"])
+
+# Read access denied: the object's token grants no read on the GPO, so the read
+# access check fails. AD silently skips such GPOs, so the script must skip it
+# too instead of treating it as a fatal error for the whole refresh.
+o = OU("/example/ReadDenied")
+o.addGPO(GPO("ReadDenied GPO"))
+o.addAccount("UserReadDenied", token_groups_sids=[], dc_token_groups_sids=[])
+
+# user_session() crash fallback: user_session() raises for this account (the
+# multi-domain referral case), so the token is assembled from tokenGroups
+# instead. The GPO is scoped to a group reported only by the Global Catalog, so
+# it applies only if the fallback resolves group membership correctly.
+o = OU("/example/SessionFallback")
+o.addGPO(GPO("SessionFallback GPO"))
+o.addAccount("UserSessionReferralFallback", token_groups_sids=["S-1-5-21-1111111111-2222222222-3333333333-512"], crash_user_session=True)
+
+# Primary group in the fallback: user_session() raises for this account and its
+# tokenGroups are empty, so the GPO -- scoped to the primary group (Domain
+# Computers) that tokenGroups omits -- applies only if the fallback adds the
+# primary group back to the token.
+o = OU("/example/PrimaryGroupFallback")
+o.addGPO(GPO("PrimaryGroupFallback GPO"))
+o.addAccount("UserPrimaryGroupFallback", token_groups_sids=[], dc_token_groups_sids=[], crash_user_session=True)
 
 # Integration tests OU and GPO
 OU("/example/IntegrationTests")

--- a/internal/testutils/admock/samba/auth/__init__.py
+++ b/internal/testutils/admock/samba/auth/__init__.py
@@ -1,8 +1,18 @@
 # TiCS: disabled # samba mock
 
+import ldb
+from samba.dcerpc import security
+
 AUTH_SESSION_INFO_DEFAULT_GROUPS = 1 << 0
 AUTH_SESSION_INFO_AUTHENTICATED = 1 << 1
 AUTH_SESSION_INFO_SIMPLE_PRIVILEGES = 1 << 2
+
+# Object SID the mock assigns to every account (matches samba.samdb get_entity).
+_OBJECT_SID = "S-1-5-21-16178157-162784614-155579044-1103"
+
+# Default well-known SIDs the LSA injects into an authenticated session token.
+_DEFAULT_SIDS = ("S-1-1-0", "S-1-5-2", "S-1-5-11")
+
 
 def system_session():
     return
@@ -12,4 +22,25 @@ class Session:
         self.security_token = b""
 
 def user_session(samdb, lp_ctx, dn, session_info_flags):
-    return Session()
+    ''' Builds the security token AD would compute for the account.
+
+    Mirrors samba.auth.user_session(): the object SID, its full (Global Catalog
+    and domain controller) group membership, and the default well-known SIDs.
+    Accounts registered in ldb.user_session_failures reproduce the multi-domain
+    referral crash where the real user_session() raises and the script must fall
+    back to assembling the token from tokenGroups. '''
+    if str(dn).lower() in ldb.user_session_failures:
+        raise RuntimeError("user_session() failed: NT_STATUS_NOT_SUPPORTED (simulated multi-domain referral)")
+
+    group_sids = ldb.token_groups_for(dn, True) + ldb.token_groups_for(dn, False)
+    token = security.token()
+    sids = ([security.dom_sid(_OBJECT_SID)]
+            + [security.dom_sid(str(s)) for s in group_sids]
+            + [security.dom_sid(s) for s in _DEFAULT_SIDS])
+    token.sids = sids
+    # Real samba keeps num_sids separate from the assigned array; set it so the
+    # token is not treated as empty (see samba.dcerpc.security.token mock).
+    token.num_sids = len(sids)
+    session = Session()
+    session.security_token = token
+    return session

--- a/internal/testutils/admock/samba/dcerpc/security/__init__.py
+++ b/internal/testutils/admock/samba/dcerpc/security/__init__.py
@@ -1,7 +1,38 @@
 # TiCS: disabled # samba mock
 
-dom_sid = ""
 descriptor = "SECURITY_DESCRIPTOR"
+
+
+class dom_sid:
+    ''' Minimal stand-in for samba.dcerpc.security.dom_sid. '''
+    def __init__(self, sid=""):
+        self.sid = sid
+
+    def __str__(self):
+        return str(self.sid)
+
+
+class token:
+    ''' Minimal stand-in for samba.dcerpc.security.token.
+
+    Reproduces a real samba quirk that a naive mock would hide: assigning .sids
+    stores the SID array but leaves num_sids untouched, and both
+    samba.security.access_check() and the .sids getter only ever see the first
+    num_sids entries. Callers must set .num_sids explicitly -- exactly as real
+    samba requires -- otherwise a token assembled from raw SIDs is silently
+    empty and grants no access. '''
+    def __init__(self):
+        self._sids = []
+        self.num_sids = 0
+
+    @property
+    def sids(self):
+        return self._sids[:self.num_sids]
+
+    @sids.setter
+    def sids(self, value):
+        # Like real samba: store the array but do not touch num_sids.
+        self._sids = list(value)
 
 SECINFO_OWNER = 1<<0
 SECINFO_GROUP = 1<<1

--- a/internal/testutils/admock/samba/samdb/__init__.py
+++ b/internal/testutils/admock/samba/samdb/__init__.py
@@ -24,6 +24,12 @@ class GPOSearch(dict):
 class SamDB:
     def __init__(self, url=None, session_info=None, credentials=None, lp=None):
         self.lp = lp
+        # The Global Catalog is reached on port 3268, the domain controller on
+        # the default LDAP port. We remember which one this connection targets so
+        # tokenGroups can return the Global Catalog view (forest-wide universal
+        # groups) or the domain controller view (domain-local groups), exactly
+        # as the two differ in real AD.
+        self.is_global_catalog = bool(url) and url.endswith(":3268")
         if url.startswith("ldap://NT_STATUS_"):
             raise Exception(1, "ldap/ldb error: %s" % url[7:])
 
@@ -59,6 +65,17 @@ class SamDB:
         # Group search
         elif "objectClass=group" in expression:
             return [{"objectSid": ["SidGroup1"]},{"objectSid": ["SidGroup2"]}]
+
+        # Token groups search. The Global Catalog and the domain controller
+        # return different memberships (forest-wide universal vs domain-local),
+        # so the result depends on which directory this connection targets.
+        elif "tokenGroups" in attrs:
+            return [{"tokenGroups": ldb.token_groups_for(base, self.is_global_catalog)}]
+
+        # Primary group lookup, used by the tokenGroups fallback to add the
+        # primary group (Domain Computers, RID 515) that tokenGroups omits.
+        elif "primaryGroupID" in attrs:
+            return [{"primaryGroupID": [b"515"]}]
 
         # OU search
         elif "gPLink" in attrs:

--- a/internal/testutils/admock/samba/security/__init__.py
+++ b/internal/testutils/admock/samba/security/__init__.py
@@ -1,5 +1,22 @@
 # TiCS: disabled # samba mock
 
+# SDDL aliases for the default well-known SIDs the LSA injects into a token.
+# Real descriptors reference them as aliases, so we map them back to verify a
+# token assembled from raw SIDs is granted read like AD would compute it.
+_SID_ALIASES = {"S-1-1-0": "WD", "S-1-5-2": "NW", "S-1-5-11": "AU"}
+
+
 def access_check(secdesc, token, flag):
     if secdesc.secdesc == "FAILED":
         raise RuntimeError("access_check() failed requested")
+
+    # Resolve the token to the trustee names used in the descriptor and grant
+    # access only if an allow ACE matches, mirroring AD: a token missing the
+    # default groups (e.g. World) fails read on a GPO scoped to Everyone.
+    trustees = set(str(s) for s in token.sids)
+    trustees.update(_SID_ALIASES[s] for s in list(trustees) if s in _SID_ALIASES)
+    for ace in secdesc.secdesc.split('(')[1:]:
+        access, _, _, _, _, trustee = ace.rstrip(')').split(';')
+        if access in ("A", "OA") and trustee in trustees:
+            return
+    raise RuntimeError("access_check() denied: token grants no read on descriptor")


### PR DESCRIPTION
In a multi-domain forest, a user can belong to a universal or foreign-domain group defined in another domain (for example, Enterprise Admins in the forest root). Building the security token with samba.auth.user_session() forces Samba to expand that membership over a single domain controller connection; the DC answers with an LDAP referral to the Global Catalog that Samba does not follow, so user_session() raises NTSTATUSError and the script crashes with an unhandled traceback. This left child-domain users unable to fetch their policies (https://github.com/ubuntu/adsys/issues/1358, https://github.com/ubuntu/adsys/issues/1256).

Query the tokenGroups constructed attribute against the Global Catalog instead: its partial replica of the whole forest yields the complete, transitive set of group SIDs without any referral chasing. The token is then assembled locally from those SIDs, removing the dependency on user_session() entirely. The token building is guarded, so any remaining environment-specific failure degrades into a clear GPO_FAILED return code rather than an opaque crash.

UDENG-10734