### PR TITLE
ci: fix TICS report action

### DIFF
--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -74,3 +74,7 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
+          # Persist TiCS debug information (including the run log) to a known
+          # location. Setting this input makes the action upload that directory
+          # as an artifact, so failing analyses can be inspected.
+          tmpdir: /tmp/tics-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -12,7 +12,7 @@ concurrency:
 env:
   apt_dependencies: >-
     ca-certificates curl dconf-cli gcc gettext git libnss-wrapper libsmbclient-dev
-    libkrb5-dev libwbclient-dev pkg-config python3-coverage samba sudo
+    libkrb5-dev libwbclient-dev pkg-config python3-coverage pylint samba sudo
     libglib2.0-dev gvfs libpam0g-dev
 
 jobs:
@@ -31,10 +31,10 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ env.apt_dependencies }}
           go install honnef.co/go/tools/cmd/staticcheck@latest
           dotnet tool install -g dotnet-reportgenerator-globaltool
-      - name: TiCS scan
+
+      - name: Merge coverage reports
         env:
-          TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 
@@ -59,10 +59,18 @@ jobs:
           reportgenerator "-reports:/tmp/coverage/*.xml" "-targetdir:.coverage" -reporttypes:Cobertura
           mv .coverage/Cobertura.xml .coverage/coverage.xml
 
-          # Install TiCS
-          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+      - name: Set up temporary directory for TiCS
+        run: |
+          mkdir -p /tmp/tics-${{ github.run_id }}-${{ github.run_attempt }}
 
-          # TiCS requires all artifacts to be built
-          go build ./cmd/...
-
-          TICSQServer -project adsys -tmpdir /tmp/tics -branchdir .
+      - name: TICS Analysis
+        env:
+          TMPDIR: /tmp/tics-${{ github.run_id }}-${{ github.run_attempt }}
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: adsys
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -2,7 +2,7 @@ name: Code quality nightly scan
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 0 * * 1" # Runs every Monday at midnight
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tics-report-daily.yaml
+++ b/.github/workflows/tics-report-daily.yaml
@@ -38,11 +38,24 @@ jobs:
         run: |
           set -e
 
-          # Download, combine and move coverage to the right place so TiCS can parse it
-          RUN_ID=$(gh run list --workflow 'QA & sanity checks' --limit 1 --status success --json databaseId -b main | jq '.[].databaseId')
-          gh run download $RUN_ID -n coverage.zip -D /tmp/coverage
-          E2E_RUN_ID=$(gh run list --workflow 'E2E - Run tests' --limit 1 --status success --json databaseId -b main | jq '.[].databaseId')
-          gh run download $E2E_RUN_ID -n pam-coverage.zip -D /tmp/coverage
+          # Download, combine and move coverage to the right place so TiCS can parse it.
+          # The Go coverage from the QA workflow is always expected to be available.
+          RUN_ID=$(gh run list --workflow 'QA & sanity checks' --limit 1 --status success --json databaseId -b main --jq '.[].databaseId')
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No successful 'QA & sanity checks' run found on main"
+            exit 1
+          fi
+          gh run download "$RUN_ID" -n coverage.zip -D /tmp/coverage
+
+          # PAM coverage comes from the E2E workflow, which may not always have a recent
+          # successful run. Treat it as best-effort so the scan still runs without it.
+          E2E_RUN_ID=$(gh run list --workflow 'E2E - Run tests' --limit 1 --status success --json databaseId -b main --jq '.[].databaseId')
+          if [ -n "$E2E_RUN_ID" ]; then
+            gh run download "$E2E_RUN_ID" -n pam-coverage.zip -D /tmp/coverage || echo "::warning::pam-coverage.zip not found in run $E2E_RUN_ID; skipping PAM coverage"
+          else
+            echo "::warning::No successful 'E2E - Run tests' run found on main; skipping PAM coverage"
+          fi
+
           reportgenerator "-reports:/tmp/coverage/*.xml" "-targetdir:.coverage" -reporttypes:Cobertura
           mv .coverage/Cobertura.xml .coverage/coverage.xml
 

--- a/.github/workflows/tics-report.yaml
+++ b/.github/workflows/tics-report.yaml
@@ -1,4 +1,4 @@
-name: Code quality nightly scan
+name: TIOBE TiCS Framework - Report
 
 on:
   schedule:


### PR DESCRIPTION
Our e2e tests are not running for a while now due to infrastructure issues; While we fix it, we should allow the reports to continue without necessarily having to merge the coverages.