### PR TITLE
debian: default fresh installs to native certificate enrollment

### DIFF
--- a/conf.example/adsys.yaml
+++ b/conf.example/adsys.yaml
@@ -18,7 +18,8 @@ global_trust_dir: /usr/local/share/ca-certificates
 #ad_backend: sssd
 
 # Certificate enrollment method: ldap (native Go, LDAP/RPC) or cepces (legacy Python/CEPCES).
-# Defaults to cepces for backward compatibility with existing installations.
+# If unset, defaults to cepces for backwards compatibility.
+# New installations default to ldap.
 #certificate_enrollment: cepces
 
 # SSSd configuration

--- a/debian/adsys.apport
+++ b/debian/adsys.apport
@@ -4,9 +4,21 @@
 '''
 
 import apport.hookutils
+import apport.packaging
 import re
 
 def add_info(report):
-    apport.hookutils.attach_related_packages(report, ["sssd", "python3-samba"])
+    related_packages = ["sssd", "python3-samba"]
+
+    # python3-cepces is only Suggested (it lives in universe), so only
+    # attach it when it is actually installed on this system.
+    try:
+        apport.packaging.get_version("python3-cepces")
+    except ValueError:
+        pass
+    else:
+        related_packages.append("python3-cepces")
+
+    apport.hookutils.attach_related_packages(report, related_packages)
     apport.hookutils.attach_journal_errors(report, 600)
     report['Syslog'] = apport.hookutils.recent_syslog(re.compile("adsys"))

--- a/debian/adsys.postinst
+++ b/debian/adsys.postinst
@@ -1,11 +1,29 @@
 #!/bin/sh
 set -e
 
+CONFFILE=/etc/adsys.yaml
+
 case "$1" in
     configure)
-        pam-auth-update --package adsys
+        DEBIAN_FRONTEND=noninteractive pam-auth-update --package adsys
+
+        # For new installations (no previous version), set the LDAP-only
+        # certificate enrollment as default. Existing installations, and
+        # any file already present (e.g. hand-created by the admin before
+        # the first install, or left behind by a previous "remove"), are
+        # left untouched: existing installations keep the code default
+        # (cepces) for backward compatibility. The file is only ever
+        # removed on "dpkg --purge" (see postrm); a plain "remove" leaves
+        # it in place.
+        if [ -z "$2" ]; then
+            if [ ! -e "$CONFFILE" ] && [ ! -L "$CONFFILE" ]; then
+                cat > "$CONFFILE" << 'EOF'
+# Certificate enrollment method: ldap (native Go, LDAP/RPC) or cepces (legacy Python/CEPCES).
+certificate_enrollment: ldap
+EOF
+            fi
+        fi
     ;;
 esac
 
 #DEBHELPER#
-

--- a/debian/adsys.postrm
+++ b/debian/adsys.postrm
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    purge)
+        # Only "dpkg --purge" removes the administrator's configuration;
+        # "remove" leaves it in place. There is no ucf/conffile machinery
+        # involved: the file is created directly by postinst (see there),
+        # so a plain rm is all that is needed here.
+        rm -f /etc/adsys.yaml
+    ;;
+esac
+
+#DEBHELPER#

--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Architecture: any
 Built-Using: ${misc:Built-Using},
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         ca-certificates,
          python3,
          python3-samba,
          samba-dsdb-modules,
@@ -45,8 +46,8 @@ Depends: ${shlibs:Depends},
 Recommends: ${misc:Recommends},
             ubuntu-advantage-desktop-daemon,
 Suggests: curlftpfs,
-          ubuntu-proxy-manager,
           python3-cepces,
+          ubuntu-proxy-manager,
 Description: ${source:Synopsis}
  ${source:Extended-Description}
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -47,6 +47,30 @@ Files: vendor/charm.land/*
 Copyright: 2020-2026 Charmbracelet, Inc.
 License: Expat
 
+Files: vendor/github.com/Azure/*
+Copyright: 2016 Microsoft
+License: Expat
+
+Files: vendor/github.com/Azure/go-ntlmssp/.golangci.yml
+       vendor/github.com/Azure/go-ntlmssp/authenticate_message.go
+       vendor/github.com/Azure/go-ntlmssp/authheader.go
+       vendor/github.com/Azure/go-ntlmssp/avids.go
+       vendor/github.com/Azure/go-ntlmssp/challenge_message.go
+       vendor/github.com/Azure/go-ntlmssp/messageheader.go
+       vendor/github.com/Azure/go-ntlmssp/negotiate_flags.go
+       vendor/github.com/Azure/go-ntlmssp/negotiate_message.go
+       vendor/github.com/Azure/go-ntlmssp/negotiator.go
+       vendor/github.com/Azure/go-ntlmssp/nlmp.go
+       vendor/github.com/Azure/go-ntlmssp/unicode.go
+       vendor/github.com/Azure/go-ntlmssp/varfield.go
+       vendor/github.com/Azure/go-ntlmssp/version.go
+Copyright: Microsoft Corporation.
+License: Expat
+
+Files: vendor/github.com/Azure/go-ntlmssp/internal/*
+Copyright: 2009 The Go Authors.
+License: Expat
+
 Files: vendor/github.com/alecthomas/*
 Copyright: 2017 Alec Thomas
 License: Expat
@@ -130,6 +154,20 @@ Copyright: 2012 The Go Authors.
            fsnotify Authors.
 License: BSD-3-clause
 
+Files: vendor/github.com/geoffgarside/*
+Copyright: 2009 The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/go-asn1-ber/*
+Copyright: 2011-2015 Michael Mitton () <mmitton@gmail.com>
+           2015-2016 go-asn1-ber Authors
+License: Expat
+
+Files: vendor/github.com/go-ldap/*
+Copyright: 2011-2015 Michael Mitton () <mmitton@gmail.com>
+           2015-2024 go-ldap Authors
+License: Expat
+
 Files: vendor/github.com/go-viper/*
 Copyright: 2013 Mitchell Hashimoto
 License: Expat
@@ -154,8 +192,27 @@ Files: vendor/github.com/gorilla/*
 Copyright: 2012-2023 The Gorilla Authors.
 License: BSD-3-clause
 
+Files: vendor/github.com/hashicorp/*
+Copyright: 2015-2022 HashiCorp, Inc.
+License: UNKNOWN
+
 Files: vendor/github.com/inconshreveable/*
 License: Apache-2.0
+
+Files: vendor/github.com/indece-official/*
+Copyright: 2019 indece
+License: Expat
+
+Files: vendor/github.com/indece-official/go-ebcdic/ebcdic.go
+Copyright: 2019 indece UG (haftungsbeschränkt)
+License: Expat
+
+Files: vendor/github.com/jcmturner/*
+License: Apache-2.0
+
+Files: vendor/github.com/jcmturner/gofork/*
+Copyright: 2009-2012 The Go Authors.
+License: BSD-3-clause
 
 Files: vendor/github.com/kardianos/*
 Copyright: 2015-2019 Daniel Theophanes.
@@ -227,6 +284,29 @@ Files: vendor/github.com/mvo5/*
 Copyright: 2013-2019 Michael Vogt
 License: UNKNOWN
 
+Files: vendor/github.com/oiweiwei/*
+Copyright: 2026 oiweiwei
+License: Expat
+
+Files: vendor/github.com/oiweiwei/go-smb2.fork/*
+Copyright: 2016 Hiroshi Ioka.
+License: BSD-2-clause
+
+Files: vendor/github.com/oiweiwei/go-smb2.fork/all.go
+       vendor/github.com/oiweiwei/go-smb2.fork/filepath.go
+Copyright: 2009 The Go Authors.
+           2016 Hiroshi Ioka.
+License: BSD-3-clause
+
+Files: vendor/github.com/oiweiwei/go-smb2.fork/internal/*
+Copyright: 2009-2016 The Go Authors.
+           2016 Hiroshi Ioka.
+License: BSD-3-clause
+
+Files: vendor/github.com/oiweiwei/gokrb5.fork/*
+Copyright: 2026 oiweiwei
+License: Apache-2.0
+
 Files: vendor/github.com/pelletier/*
 Copyright: 2021-2023 Thomas Pelletier
 License: Expat
@@ -241,6 +321,10 @@ License: BSD-3-clause
 
 Files: vendor/github.com/rivo/*
 Copyright: 2019 Oliver Kuederle
+License: Expat
+
+Files: vendor/github.com/rs/*
+Copyright: 2017 Olivier Poitrey
 License: Expat
 
 Files: vendor/github.com/russross/*
@@ -365,7 +449,6 @@ Files: vendor/go.yaml.in/yaml/v3/decode.go
        vendor/go.yaml.in/yaml/v3/resolve.go
        vendor/go.yaml.in/yaml/v3/sorter.go
        vendor/go.yaml.in/yaml/v3/yaml.go
-       vendor/go.yaml.in/yaml/v3/NOTICE
 Copyright: 2011-2019 Canonical Ltd
 License: Apache-2.0
 
@@ -436,7 +519,6 @@ Files: vendor/gopkg.in/yaml.v3/decode.go
        vendor/gopkg.in/yaml.v3/resolve.go
        vendor/gopkg.in/yaml.v3/sorter.go
        vendor/gopkg.in/yaml.v3/yaml.go
-       vendor/gopkg.in/yaml.v3/NOTICE
 Copyright: 2011-2019 Canonical Ltd
 License: Apache-2.0
 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -7,3 +7,10 @@ Depends: @builddeps@
 Test-Command: ./debian/tests/test sudo
 Restrictions: allow-stderr, needs-root, skippable
 Depends: @builddeps@
+
+# Exercise packaging-level guarantees on the built binary package: the
+# ca-certificates runtime dependency (M11) and the /etc/adsys.yaml
+# lifecycle across fresh install, reinstall, remove and purge (M12).
+Test-Command: ./debian/tests/packaging-smoke
+Restrictions: allow-stderr, needs-root, skippable
+Depends: @, ca-certificates

--- a/debian/tests/packaging-smoke
+++ b/debian/tests/packaging-smoke
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Packaging-level smoke test for the adsys binary package lifecycle.
+#
+# Covers:
+#  - M11: adsys directly depends on ca-certificates because the native LDAP
+#    certificate backend requires update-ca-certificates to be present.
+#  - M12: /etc/adsys.yaml is only ever created by postinst on a genuinely
+#    new install (dpkg's "most-recently-configured-version" is empty) that
+#    finds no file already in place, and is only ever removed by postrm on
+#    purge, never on a plain remove. So an administrator's edits, or any
+#    file already present before the very first install, always survive
+#    upgrades, reinstalls and remove.
+set -e
+
+CONFFILE=/etc/adsys.yaml
+PKG=adsys
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Resolve the exact package-under-test candidate version and pin every
+# install/reinstall to it below, so this test always exercises the
+# freshly built package and fails loudly instead of silently falling back
+# to some other version an archive mirror configured in the testbed might
+# offer.
+CANDIDATE=$(apt-cache policy "$PKG" | awk '/Candidate:/ {print $2}')
+[ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "(none)" ] \
+    || fail "could not determine an install candidate for $PKG"
+
+assert_installed_version() {
+    INSTALLED=$(dpkg-query -W -f='${Version}' "$PKG" 2>/dev/null || true)
+    [ "$INSTALLED" = "$CANDIDATE" ] \
+        || fail "expected $PKG $CANDIDATE to be installed, got '${INSTALLED:-<none>}'"
+}
+
+# Plain install: used both for a genuinely fresh/first configure and for
+# reinstalling over a "config-files" (removed but not purged) package.
+apt_install() {
+    apt-get install -y "${PKG}=${CANDIDATE}"
+    assert_installed_version
+}
+
+# Forces maintainer scripts to rerun even though the same version is
+# already fully installed, to simulate an upgrade-like reconfigure.
+apt_reinstall() {
+    apt-get install --reinstall -y "${PKG}=${CANDIDATE}"
+    assert_installed_version
+}
+
+echo "== M11: ca-certificates is a direct runtime dependency =="
+command -v update-ca-certificates >/dev/null 2>&1 \
+    || fail "update-ca-certificates is not available; ca-certificates dependency is missing or broken"
+dpkg-query -W -f='${Depends}\n' "$PKG" | tr ',' '\n' | grep -qw 'ca-certificates' \
+    || fail "$PKG no longer declares a direct dependency on ca-certificates"
+
+echo "== M12: /etc/adsys.yaml lifecycle (candidate: $CANDIDATE) =="
+
+# Fresh install: autopkgtest already installed the package under test, so
+# the LDAP default must be in place.
+assert_installed_version
+[ -e "$CONFFILE" ] || fail "$CONFFILE is missing after a fresh install"
+grep -q '^certificate_enrollment: ldap$' "$CONFFILE" \
+    || fail "$CONFFILE does not contain the expected fresh-install default"
+
+# Simulate an administrator edit, then an upgrade-like reconfigure of the
+# already-installed package (most-recently-configured-version is set):
+# local edits must survive untouched.
+echo "# local-admin-edit-marker" >> "$CONFFILE"
+apt_reinstall
+grep -q 'local-admin-edit-marker' "$CONFFILE" \
+    || fail "reinstalling $PKG discarded administrator edits to $CONFFILE"
+
+# Plain remove must keep the conffile around (postrm only acts on purge).
+apt-get remove -y "$PKG"
+[ -e "$CONFFILE" ] || fail "'apt-get remove' deleted $CONFFILE; it must survive until purge"
+grep -q 'local-admin-edit-marker' "$CONFFILE" \
+    || fail "$CONFFILE lost its content across 'apt-get remove'"
+
+# Installing again over the "config-files" state left by remove still has
+# a most-recently-configured-version recorded by dpkg, so postinst must
+# not touch the file at all.
+apt_install
+grep -q 'local-admin-edit-marker' "$CONFFILE" \
+    || fail "reinstalling over the config-files state lost administrator edits"
+
+# Purge must remove the file.
+apt-get purge -y "$PKG"
+[ ! -e "$CONFFILE" ] || fail "'apt-get purge' left $CONFFILE behind"
+
+# A file created by an administrator after a purge, while the package is
+# fully uninstalled, must be preserved by the next install: this is the
+# genuinely-new-install-with-a-pre-existing-file case, and the only one
+# where postinst's "file already present" guard actually has to trigger.
+printf '# custom-pre-existing-marker\ncertificate_enrollment: cepces\n' > "$CONFFILE"
+apt_install
+grep -q 'custom-pre-existing-marker' "$CONFFILE" \
+    || fail "installing over a file created after purge lost its content"
+grep -q '^certificate_enrollment: cepces$' "$CONFFILE" \
+    || fail "installing over a pre-existing file changed its certificate_enrollment setting"
+
+# Leave the testbed in a clean, usable state: purge the custom file away
+# and reinstall so a plain fresh LDAP default is in place again.
+apt-get purge -y "$PKG"
+apt_install
+[ -e "$CONFFILE" ] || fail "$CONFFILE is missing after the final reinstall"
+grep -q '^certificate_enrollment: ldap$' "$CONFFILE" \
+    || fail "$CONFFILE does not contain the expected default after the final reinstall"
+
+echo "OK"

--- a/docs/explanation/certificates.md
+++ b/docs/explanation/certificates.md
@@ -37,7 +37,14 @@ The **`cepces`** method is the legacy implementation that delegates certificate 
 
 ### Configuration
 
-The default method is `cepces` for backward compatibility; new installations should opt into the native `ldap` enrollment. For the configuration steps and the package requirements of each method, see {ref}`howto::certificates-configure`.
+Set the enrollment method in `/etc/adsys.yaml`:
+
+```yaml
+certificate_enrollment: ldap    # or "cepces"
+```
+
+* **New installations**: The package creates `/etc/adsys.yaml` with `certificate_enrollment: ldap` when no configuration file exists yet.
+* **Existing installations**: The default is `cepces` for backward compatibility. To switch to the native LDAP enrollment, add the setting above to your configuration file.
 
 To ensure idempotency when applying the policy, enrollment state is persisted as a JSON file at `/var/lib/adsys/certs/state_$(hostname).<object-id>.json`, which contains information pertaining to the enrolled certificate(s).
 

--- a/docs/reference/adsys-daemon.md
+++ b/docs/reference/adsys-daemon.md
@@ -116,8 +116,6 @@ It will gracefully shutdown after idling for a short period of time (default: 12
 
 ## Configuration
 
-`ADSys` doesn’t ship a configuration file by default. 
-
 System-wide or user-specific configuration files can be created to modify the behavior of the daemon and the client:
 
 * System-wide: defined in `/etc/adsys.yaml` and applies to both daemon and client.
@@ -148,6 +146,11 @@ run_dir: /tmp/adsysd/run
 # Backend selection: sssd (default) or winbind
 ad_backend: sssd
 
+# Certificate enrollment method: cepces (default) or ldap
+# If unset, defaults to cepces for backwards compatibility.
+# New installations default to ldap.
+certificate_enrollment: ldap
+
 # SSSD configuration
 sssd:
   config: /etc/sssd.conf
@@ -170,6 +173,11 @@ Increase the verbosity of the daemon or client. By default, only warnings and er
 
 * **socket**
 Path the Unix socket for communication between clients and daemon. This can be overridden by the `--socket` option. Defaults to `/run/adsysd.sock` (monitored by systemd for socket activation).
+
+* **certificate_enrollment**
+
+Method used for certificate enrollment. Can be either `cepces` (default) or `ldap`. This can be overridden by the `--certificate-enrollment` option.
+New installations will be auto-configured to use `ldap`. If unset, defaults to `cepces` for backwards compatibility.
 
 ### Service only configuration
 

--- a/e2e/cmd/run_tests/01_provision_client/main.go
+++ b/e2e/cmd/run_tests/01_provision_client/main.go
@@ -191,7 +191,7 @@ func action(ctx context.Context, cmd *command.Command) error {
 	// TODO: remove this once the packages installed below are MIRed and installed by default with adsys
 	// Allow errors here on account on packages not being available on the tested Ubuntu version
 	log.Infof("Installing universe packages required for some policy managers...")
-	if _, err := client.Run(ctx, "DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-proxy-manager python3-cepces"); err != nil {
+	if _, err := client.Run(ctx, "DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-proxy-manager"); err != nil {
 		log.Warningf("Some packages failed to install: %v", err)
 	}
 

--- a/e2e/cmd/run_tests/11_test_pro_managers/main.go
+++ b/e2e/cmd/run_tests/11_test_pro_managers/main.go
@@ -174,10 +174,62 @@ func action(ctx context.Context, cmd *command.Command) (err error) {
 	// Assert policies only available in newer adsys releases
 	if !slices.Contains([]string{"focal", "jammy"}, cmd.Inventory.Codename) {
 		/// Certificates
-		// Enrollment takes a few seconds, so no better way to do this than an arbitrary sleep :)
-		time.Sleep(5 * time.Second)
-		if err := rootClient.RequireContains(ctx, "getcert list -i warthogs-CA.Machine", "status: MONITORING"); err != nil {
+		// A fresh package installation defaults to the native LDAP enrollment
+		// method. Pin the selection anyway so the assertions do not depend on
+		// whether the base image already carried an adsys configuration.
+		if err := applyCertificateEnrollment(ctx, rootClient, "ldap"); err != nil {
 			return err
+		}
+
+		// First native enrollment. Validate it through the management CLI:
+		// health, certificate/key correspondence, chain and system trust.
+		if err := requireEventuallyContains(ctx, rootClient, "adsysctl certificate list", "status: healthy"); err != nil {
+			return err
+		}
+		if err := rootClient.RequireContains(ctx, "adsysctl certificate list", "template: Machine"); err != nil {
+			return err
+		}
+		if err := rootClient.RequireContains(ctx, "adsysctl certificate list", "key matches certificate: yes"); err != nil {
+			return err
+		}
+		if err := rootClient.RequireContains(ctx, "adsysctl certificate cas", "installed in trust store: yes"); err != nil {
+			return err
+		}
+		if err := rootClient.RequireContains(ctx, "adsysctl certificate verify", "PASS"); err != nil {
+			return err
+		}
+
+		// Renewal re-enrolls against the live CA.
+		if _, err := rootClient.Run(ctx, "adsysctl certificate renew --all"); err != nil {
+			return fmt.Errorf("certificate renewal failed: %w", err)
+		}
+		if err := rootClient.RequireContains(ctx, "adsysctl certificate list", "status: healthy"); err != nil {
+			return err
+		}
+
+		// The legacy CEPCES backend remains supported when selected explicitly.
+		if _, err := rootClient.Run(ctx, "DEBIAN_FRONTEND=noninteractive apt-get install -y certmonger python3-cepces"); err != nil {
+			return err
+		}
+		if err := applyCertificateEnrollment(ctx, rootClient, "cepces"); err != nil {
+			return err
+		}
+		if err := requireEventuallyContains(ctx, rootClient, "getcert list -i warthogs-CA.Machine", "status: MONITORING"); err != nil {
+			return err
+		}
+
+		// Switching back to the native method must retire the certmonger
+		// requests instead of leaving certmonger managing the same files.
+		if err := applyCertificateEnrollment(ctx, rootClient, "ldap"); err != nil {
+			return err
+		}
+		if err := requireEventuallyContains(ctx, rootClient, "adsysctl certificate list", "status: healthy"); err != nil {
+			return err
+		}
+		// The request must be gone entirely: a request left in an error or
+		// transitional state still means certmonger owns the same files.
+		if _, err := rootClient.Run(ctx, "! getcert list -i warthogs-CA.Machine 2>/dev/null | grep -q 'Request ID'"); err != nil {
+			return fmt.Errorf("certmonger still tracks warthogs-CA.Machine after switching to LDAP enrollment: %w", err)
 		}
 
 		/// Proxy
@@ -274,5 +326,62 @@ ftp_proxy="http://127.0.0.1:8080"`); err != nil {
 	}
 	////// End policies for $HOST-ADM@WARTHOGS.BIZ
 
+	return nil
+}
+
+// requireEventuallyContains polls cmd until its output contains expected or the
+// timeout elapses, returning the last error on timeout. Certificate enrollment
+// and backend switches complete asynchronously, so assertions on their results
+// must tolerate a delay.
+func requireEventuallyContains(ctx context.Context, client remote.Client, cmd, expected string) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	var err error
+	for {
+		if err = client.RequireContains(ctx, cmd, expected); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+// applyCertificateEnrollment pins the certificate enrollment method and makes
+// the daemon act on it.
+//
+// The daemon builds its certificate manager once, at startup, and its
+// configuration reload only covers verbosity, socket and timeout: the backend
+// of a running daemon never changes. Restarting adsys-gpo-refresh alone would
+// therefore ask the previously configured daemon to update policy, so adsysd is
+// restarted first and the refresh triggered afterwards.
+func applyCertificateEnrollment(ctx context.Context, client remote.Client, method string) error {
+	if err := setCertificateEnrollment(ctx, client, method); err != nil {
+		return err
+	}
+	if _, err := client.Run(ctx, "systemctl restart adsysd.service"); err != nil {
+		return fmt.Errorf("failed to restart adsysd after selecting the %q enrollment method: %w", method, err)
+	}
+	if _, err := client.Run(ctx, "systemctl restart adsys-gpo-refresh"); err != nil {
+		return fmt.Errorf("failed to refresh policies after selecting the %q enrollment method: %w", method, err)
+	}
+	return nil
+}
+
+// setCertificateEnrollment pins the certificate enrollment method in
+// /etc/adsys.yaml, replacing the key when present and appending it otherwise.
+// The file is created first: an upgraded or base image may not ship one, and
+// sed would fail on the missing file.
+func setCertificateEnrollment(ctx context.Context, client remote.Client, method string) error {
+	_, err := client.Run(ctx, fmt.Sprintf(
+		"touch /etc/adsys.yaml && sed -i -e 's/^certificate_enrollment:.*/certificate_enrollment: %s/' /etc/adsys.yaml && (grep -q '^certificate_enrollment:' /etc/adsys.yaml || echo 'certificate_enrollment: %s' >> /etc/adsys.yaml)",
+		method, method))
+	if err != nil {
+		return fmt.Errorf("failed to set certificate enrollment method to %q: %w", method, err)
+	}
 	return nil
 }

--- a/e2e/scripts/Dockerfile.build
+++ b/e2e/scripts/Dockerfile.build
@@ -14,10 +14,29 @@ ARG CODENAME=latest
 
 # Keep the codename list easy to maintain, keeping in mind that we might need to
 # add more as the need to backport various packages arises.
-RUN if echo "focal" | grep -q "$CODENAME"; then \
+#
+# focal and noble don't ship a new enough golang-go for adsys (noble notably
+# lacks golang-1.25-go, required by debian/rules - see e2e/scripts/patches -
+# to satisfy the go.mod go 1.25 requirement without forcing an older
+# toolchain with GOTOOLCHAIN=local). ppa:ubuntu-enterprise-desktop/golang
+# publishes golang-1.25-go for noble (confirmed via the Launchpad API), so
+# reuse that existing, already-trusted Canonical PPA rather than adding a new
+# supply-chain dependency.
+RUN if [ "$CODENAME" = "focal" ] || [ "$CODENAME" = "noble" ]; then \
         set -ex \
         && apt-get install -y software-properties-common \
         && add-apt-repository -y ppa:ubuntu-enterprise-desktop/golang; \
+    fi
+
+# jammy doesn't have golang-1.25-go published in
+# ppa:ubuntu-enterprise-desktop/golang (confirmed via the Launchpad API), nor
+# in its archive/security/updates pockets. Fall back to the actively
+# maintained community backports PPA referenced by upstream Go
+# (https://github.com/golang/go/wiki/Ubuntu) for jammy only.
+RUN if [ "$CODENAME" = "jammy" ]; then \
+        set -ex \
+        && apt-get install -y software-properties-common \
+        && add-apt-repository -y ppa:longsleep/golang-backports; \
     fi
 
 RUN set -ex \

--- a/e2e/scripts/patches/jammy.patch
+++ b/e2e/scripts/patches/jammy.patch
@@ -1,5 +1,5 @@
 diff --git a/debian/control b/debian/control
-index ccf213e0..2d34a328 100644
+index f11b86fe..48220d7d 100644
 --- a/debian/control
 +++ b/debian/control
 @@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
@@ -12,23 +12,15 @@ index ccf213e0..2d34a328 100644
                 dbus,
                 libdbus-1-dev,
 diff --git a/debian/rules b/debian/rules
-index f9705a3d..3bf891b4 100755
+index f9705a3d..d7dc0b1c 100755
 --- a/debian/rules
 +++ b/debian/rules
-@@ -29,6 +29,9 @@ export ADSYS_SKIP_INTEGRATION_TESTS=1
- # as long as it matches the go.mod go stenza which is the language requirement.
- export GOTOOLCHAIN := local
+@@ -31,2 +31,5 @@ export GOTOOLCHAIN := local
 
 +# Run with Go 1.25
 +export PATH := /usr/lib/go-1.25/bin/:$(PATH)
 +
  %:
-        dh $@ --buildsystem=golang --with=golang,apport
-
-@@ -87,3 +90,5 @@ endif
-        ln -s adsysd debian/tmp/sbin/adsysctl
-        # Run go generate to install assets, but don’t regenerate them
-        GENERATE_ONLY_INSTALL_TO_DESTDIR=$(CURDIR)/debian/tmp go generate -x $(GOFLAGS),tools ./...
+@@ -89,0 +90,2 @@ endif
 +
 +override_dh_dwz:
-

--- a/e2e/scripts/patches_test.go
+++ b/e2e/scripts/patches_test.go
@@ -1,0 +1,79 @@
+package scripts_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/adsys/e2e/scripts"
+	"github.com/ubuntu/adsys/internal/testutils"
+)
+
+// TestReleasePatchesApplyCleanly ensures that every per-release patch under
+// e2e/scripts/patches still applies to the current debian/ packaging tree,
+// using the exact patch invocation performed by e2e/scripts/build-deb.sh.
+//
+// These patches only ever touch debian/control and debian/rules, so this is a
+// cheap, deterministic, network-free check: it does not build any package,
+// it merely replays build-deb.sh's `patch` invocation against a scratch copy
+// of debian/. If debian/control or debian/rules drift (e.g. a Build-Depends
+// or Go toolchain change) without the patches being refreshed, this test
+// fails instead of only surfacing the problem later inside a Docker-based
+// e2e build.
+func TestReleasePatchesApplyCleanly(t *testing.T) {
+	// patch is part of the normal Ubuntu/build-essential environment already
+	// relied upon by this repository (e.g. build-deb.sh itself requires it).
+	// Fail loudly rather than skipping if it is missing, since silently
+	// skipping would defeat the purpose of this check as a CI guard against
+	// stale patch context.
+	_, err := exec.LookPath("patch")
+	require.NoError(t, err, "Setup: patch command not available")
+
+	rootDir, err := scripts.RootDir()
+	require.NoError(t, err, "Setup: could not determine repository root directory")
+
+	patchesDir := filepath.Join(rootDir, "e2e", "scripts", "patches")
+	entries, err := os.ReadDir(patchesDir)
+	require.NoError(t, err, "Setup: could not list patches directory")
+
+	var codenames []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".patch") {
+			continue
+		}
+		codenames = append(codenames, strings.TrimSuffix(entry.Name(), ".patch"))
+	}
+	require.NotEmpty(t, codenames, "Setup: expected to find at least one release patch to validate")
+
+	for _, codename := range codenames {
+		t.Run(codename, func(t *testing.T) {
+			// Only debian/ is patched, so limit the scratch copy to it to
+			// keep this check cheap.
+			workDir := t.TempDir()
+			testutils.Copy(t, filepath.Join(rootDir, "debian"), filepath.Join(workDir, "debian"))
+
+			patchData, err := os.ReadFile(filepath.Join(patchesDir, codename+".patch"))
+			require.NoErrorf(t, err, "Setup: could not read patch for %s", codename)
+
+			rejectedPath := filepath.Join(workDir, "rejected")
+			// Mirror build-deb.sh verbatim:
+			//   patch --ignore-whitespace --no-backup-if-mismatch -r /tmp/rejected -p1 < /patches/${codename}.patch
+			// #nosec G204 -- fixed trusted binary, no user-controlled arguments
+			cmd := exec.Command("patch", "--ignore-whitespace", "--no-backup-if-mismatch", "-r", rejectedPath, "-p1")
+			cmd.Dir = workDir
+			cmd.Stdin = bytes.NewReader(patchData)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				msg := string(out)
+				if rejected, rerr := os.ReadFile(rejectedPath); rerr == nil {
+					msg += "\nRejected hunks:\n" + string(rejected)
+				}
+				t.Fatalf("%s.patch no longer applies cleanly to debian/control and debian/rules - refresh it:\n%s", codename, msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Final part of the LDAP certificate enrollment work: flip fresh installs to the native backend and make the e2e suite prove which backend it actually tested.

> **This is part 4 of 4**, split out of #1401.
> `#1448` → `#1449 (engine)` → `#1450 (API/CLI)` → **this PR**.
> Targets `split/certificate-management`; will be retargeted to `main` as its parents land.

## What this contains

**Packaging**
- `/etc/adsys.yaml` is written with `certificate_enrollment: ldap` **on first install only**, and removed on purge. Upgrades and reinstalls keep whatever is already there, so no existing machine changes how it enrolls.
- `python3-cepces` moves from `Recommends` to `Suggests` — adsys is in `main` and `python3-cepces` is still in `universe`, so recommending it would pull a universe package into a main package's default install set.
- `ca-certificates` added to `Depends` (the native path installs discovered CA chains).
- Go build dependency raised to the version `go.mod` already declares.
- New packaging smoke autopkgtest covering install / upgrade / remove / purge.

**e2e**
- The certificate assertion previously called `getcert`, so it only ever proved the CEPCES path. It now pins the backend and asserts what that backend should produce: for the native method the health, key match, chain and trust-store presence, plus renewal; for CEPCES the existing certmonger tracking; and the migration between the two.
- The Jammy/Noble backport patches stopped applying after the Go bump, which only surfaced inside a Docker build. Regenerated, plus a test that replays `build-deb.sh`'s patch invocation so packaging drift fails fast and locally.

## Note for reviewers

`/etc/adsys.yaml` is created by `postinst` rather than shipped as a conffile. That is deliberate: it is a first-install default, not a package-owned configuration, so dpkg must not prompt about it or restore it after an administrator removes it. The reasoning is recorded inline in the maintainer script.


UDENG-11277