### PR TITLE
d/copyright: Fix d/copyright with helper script

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -25,125 +25,399 @@ Copyright: 2020-2021 Canonical Ltd.
            Based on work by Andrew Tridgell 2010 and Amitay Isaacs 2011-2012.
 License: GPL-3+
 
+Files: .github/samba/python/samba/gp/gp_cert_auto_enroll_ext.py
+       internal/policies/certificate/python/vendor_samba/gp/gp_cert_auto_enroll_ext.py
+Copyright: 2021 David Mulder <dmulder@suse.com>
+License: GPL-3+
+
+Files: .github/samba/python/samba/gp/gpclass.py
+       internal/policies/certificate/python/vendor_samba/gp/gpclass.py
+Copyright: 2013 Luke Morrison <luc785@.hotmail.com>
+License: GPL-3+
+
+Files: .github/samba/python/samba/gp/util/logging.py
+       internal/policies/certificate/python/vendor_samba/gp/util/logging.py
+Copyright: 2019-2020 BaseALT Ltd.
+           2022 David Mulder <dmulder@suse.com>
+License: GPL-3+
+
+# Vendored files
+
+Files: vendor/charm.land/*
+Copyright: 2020-2026 Charmbracelet, Inc.
+License: Expat
+
+Files: vendor/github.com/alecthomas/*
+Copyright: 2017 Alec Thomas
+License: Expat
+
+Files: vendor/github.com/alecthomas/chroma/v2/formatters/svg/font_liberation_mono.go
+Copyright: 2010 Google Corporation
+           2012 Red Hat, Inc.
+License: OFL-1.1
+
+Files: vendor/github.com/atotto/*
+Copyright: 2013 Ato Araki.
+License: BSD-3-clause
+
+Files: vendor/github.com/atotto/clipboard/clipboard.go
+       vendor/github.com/atotto/clipboard/clipboard_darwin.go
+       vendor/github.com/atotto/clipboard/clipboard_plan9.go
+       vendor/github.com/atotto/clipboard/clipboard_unix.go
+       vendor/github.com/atotto/clipboard/clipboard_windows.go
+Copyright: 2013 @atotto.
+License: BSD-3-clause
+
+Files: vendor/github.com/aymanbagabas/*
+Copyright: 2022 Ayman Bagabas
+License: Expat
+
+Files: vendor/github.com/aymerick/*
+Copyright: 2015 Aymerick JEHANNE
+License: Expat
+
+Files: vendor/github.com/charmbracelet/*
+Copyright: 2019-2025 Charmbracelet, Inc.
+License: Expat
+
+Files: vendor/github.com/clipperhouse/*
+Copyright: 2020-2025 Matt Sherman
+License: Expat
+
 Files: vendor/github.com/coreos/*
-Copyright: 2015-2018 CoreOS, Inc. / 2014 Docker, Inc.
+Copyright: 2015-2020 CoreOS, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/coreos/go-systemd/v22/activation/files.go
+Copyright: 2026 RedHat, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/coreos/go-systemd/v22/daemon/sdnotify.go
+Copyright: 2014 Docker, Inc.
+           2015-2018 CoreOS, Inc.
 License: Apache-2.0
 
 Files: vendor/github.com/cpuguy83/*
 Copyright: 2014 Brian Goff
-License: MIT
+License: Expat
 
 Files: vendor/github.com/davecgh/*
 Copyright: 2012-2016 Dave Collins <dave@davec.name>
 License: ISC
 
+Files: vendor/github.com/dlclark/*
+Copyright: Doug Clark
+License: Expat
+
+Files: vendor/github.com/dlclark/regexp2/ATTRIB
+Copyright: Microsoft Corporation
+License: Expat
+
+Files: vendor/github.com/dsnet/*
+Copyright: 2014 Joe Tsai and The Go Authors.
+License: UNKNOWN
+
+Files: vendor/github.com/dsnet/golib/memfile/file.go
+Copyright: 2017 Joe Tsai.
+License: UNKNOWN
+
 Files: vendor/github.com/fatih/*
 Copyright: 2013 Fatih Arslan
-License: MIT
+License: Expat
 
 Files: vendor/github.com/fsnotify/*
-Copyright: 2010-2015 fsnotify Authors. / The Go Authors.
-License: BSD-3
+Copyright: 2012 The Go Authors.
+           fsnotify Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/go-viper/*
+Copyright: 2013 Mitchell Hashimoto
+License: Expat
+
+Files: vendor/github.com/go-viper/mapstructure/v2/internal/*
+Copyright: 2022 The Go Authors.
+License: Expat
 
 Files: vendor/github.com/godbus/*
 Copyright: 2013 Georg Reinke (<guelfey at gmail dot com>), Google
-License: BSD-2
+License: BSD-2-clause
 
 Files: vendor/github.com/golang/*
 Copyright: 2010-2019 The Go Authors.
-License: BSD-3
+License: BSD-3-clause
 
-Files: vendor/github.com/hashicorp/*
-Copyright: HashiCorp
-License: MPL-2.0
+Files: vendor/github.com/google/*
+Copyright: 2009-2023 Google Inc.
+License: BSD-3-clause
+
+Files: vendor/github.com/gorilla/*
+Copyright: 2012-2023 The Gorilla Authors.
+License: BSD-3-clause
 
 Files: vendor/github.com/inconshreveable/*
-Copyright: 2014 Alan Shreve
 License: Apache-2.0
 
-Files: vendor/github.com/magiconair/*
-Copyright: 2013-2018 Frank Schroeder.
-License: BSD-2
+Files: vendor/github.com/kardianos/*
+Copyright: 2015-2019 Daniel Theophanes.
+License: Zlib
+
+Files: vendor/github.com/kr/*
+Copyright: 2012 The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/leonelquinteros/*
+Copyright: 2016 Leonel Quinteros
+License: BSD-3-clause or Expat
+
+Files: vendor/github.com/leonelquinteros/gotext/helper.go
+       vendor/github.com/leonelquinteros/gotext/locale.go
+       vendor/github.com/leonelquinteros/gotext/mo.go
+       vendor/github.com/leonelquinteros/gotext/po.go
+       vendor/github.com/leonelquinteros/gotext/translation.go
+       vendor/github.com/leonelquinteros/gotext/translator.go
+Copyright: 2018 DeineAgentur UG https:
+           www.deineagentur.com.
+License: Expat
+
+Files: vendor/github.com/leonelquinteros/gotext/plurals/*
+Copyright: 2016 Jonas Obrist (https:
+           2018 DeineAgentur UG https:
+           gettext.go)
+           github.com
+           ojii
+           www.deineagentur.com
+License: BSD-3-clause
+
+Files: vendor/github.com/leonelquinteros/gotext/plurals/genfixture.py
+Copyright: 2016 Jonas Obrist (https:
+           gettext.go)
+           github.com
+           ojii
+License: BSD-3-clause
+
+Files: vendor/github.com/lucasb-eyer/*
+Copyright: 2013 Lucas Beyer
+License: Expat
+
+Files: vendor/github.com/maruel/*
+Copyright: 2018 Marc-Antoine Ruel.
+License: Apache-2.0
 
 Files: vendor/github.com/mattn/*
-Copyright: 2016 Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
-License: MIT
+Copyright: 2016 Yasuhiro Matsumoto <mattn.jp@gmail.com>
+License: Expat
+
+Files: vendor/github.com/microcosm-cc/*
+Copyright: 2014-2019 David Kitchen <david@buro9.com>
+License: BSD-3-clause
 
 Files: vendor/github.com/mitchellh/*
 Copyright: 2013 Mitchell Hashimoto
-License: MIT
+License: Expat
+
+Files: vendor/github.com/muesli/*
+Copyright: 2019 Christian Muehlhaeuser
+License: Expat
+
+Files: vendor/github.com/muesli/cancelreader/*
+Copyright: 2022 Erik Geiser and Christian Muehlhaeuser
+License: Expat
 
 Files: vendor/github.com/mvo5/*
 Copyright: 2013-2019 Michael Vogt
-License: MIT
+License: UNKNOWN
 
 Files: vendor/github.com/pelletier/*
-Copyright: 2013-2017 Thomas Pelletier, Eric Anderton
-License: MIT
+Copyright: 2021-2023 Thomas Pelletier
+License: Expat
+
+Files: vendor/github.com/pkg/*
+Copyright: 2013 Dave Cheney
+License: BSD-2-clause
 
 Files: vendor/github.com/pmezard/*
 Copyright: 2013 Patrick Mezard
-License: BSD-3
+License: BSD-3-clause
+
+Files: vendor/github.com/rivo/*
+Copyright: 2019 Oliver Kuederle
+License: Expat
 
 Files: vendor/github.com/russross/*
 Copyright: 2011 Russ Ross <russ@russross.com>
-License: BSD-2
+License: BSD-2-clause
+
+Files: vendor/github.com/sagikazarmark/*
+Copyright: 2023 Márk Sági-Kazár <mark.sagikazar@gmail.com>
+License: Expat
 
 Files: vendor/github.com/sirupsen/*
-Copyright: 2012 Miki Tebeka <miki.tebeka@gmail.com> / 2014 Simon Eskildsen
-License: MIT
+Copyright: 2014 Simon Eskildsen
+License: Expat
 
-Files: vendor/github.com/spf13/*
-Copyright: 2011 The Go Authors.
-           2014-2015 Steve Francia <spf@spf13.com>.
-License: MIT
+Files: vendor/github.com/sirupsen/logrus/alt_exit.go
+Copyright: 2012 Miki Tebeka <miki.tebeka@gmail.com>
+License: Expat
+
+Files: vendor/github.com/sourcegraph/*
+Copyright: 2023 Sourcegraph
+License: Expat
 
 Files: vendor/github.com/spf13/afero/*
-Copyright: 2014-2016 Steve Francia <spf@spf13.com>.
+Copyright: 2014-2022 Steve Francia <spf@spf13.com>
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/afero.go
+       vendor/github.com/spf13/afero/os.go
+Copyright: 2013 tsuru authors.
+           2014 Steve Francia <spf@spf13.com>
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/ioutil.go
+       vendor/github.com/spf13/afero/match.go
+       vendor/github.com/spf13/afero/path.go
+Copyright: 2015 Steve Francia <spf@spf13.com>
+           2015 The Go Authors
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/mem/file.go
+Copyright: 2013 tsuru authors.
+           2015 Steve Francia <spf@spf13.com>
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/util.go
+Copyright: 2015 Steve Francia <spf@spf13.com>
            2015 The Hugo Authors
-           2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
-           2009-2015 The Go Authors.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/cast/*
+Copyright: 2014 Steve Francia <spf@spf13.com>
+License: Expat
+
+Files: vendor/github.com/spf13/cobra/*
+Copyright: 2013-2023 The Cobra Authors
 License: Apache-2.0
 
 Files: vendor/github.com/spf13/pflag/*
-Copyright: 2009-2012 The Go Authors.
-           2012 Alex Ogier.
-License: Apache-2.0
+Copyright: 2012 Alex Ogier.
+           2012 The Go Authors.
+License: BSD-3-clause
 
-Files: vendor/github.com/spf13/cobra/*
-Copyright: 2013 Steve Francia <spf@spf13.com>.
-           2015 Red Hat Inc.
-           2016 French Ben.
-License: Apache-2.0
+Files: vendor/github.com/spf13/pflag/flag.go
+       vendor/github.com/spf13/pflag/golangflag.go
+Copyright: 2009 The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/spf13/viper/*
+Copyright: 2014 Steve Francia <spf@spf13.com>
+License: Expat
 
 Files: vendor/github.com/stretchr/*
-Copyright: 2012-2020 Mat Ryer
-           Tyler Bunnell and contributors.
-License: MIT
+Copyright: 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+License: Expat
 
 Files: vendor/github.com/subosito/*
 Copyright: 2013 Alif Rachmawadi
-License: MIT
+License: Expat
 
-Files: vendor/github.com/termie/*
-Copyright: Andy Smith
-License: MIT
+Files: vendor/github.com/ubuntu/decorate/*
+Copyright: 2022-2023 Canonical Ltd.
+License: Expat
 
-Files: vendor/*golang.org/*
-Copyright: 2009-2020 The Go Authors.
-License: BSD-3
+Files: vendor/github.com/ubuntu/go-i18n/*
+Copyright: 2023 Ubuntu
+License: Expat
+
+Files: vendor/github.com/xo/*
+Copyright: 2016 Anmol Sethi
+License: Expat
+
+Files: vendor/github.com/yuin/*
+Copyright: 2019-2020 Yusuke Inuzuka
+License: Expat
+
+Files: vendor/go.yaml.in/*
+Copyright: 2006-2011 Kirill Simonov
+           2011 staring in  when the project was ported over:
+           2011-2016 Canonical Ltd.
+License: Apache-2.0 or Expat
+
+Files: vendor/go.yaml.in/yaml/v3/README.md
+Copyright: 2006-2011 Kirill Simonov
+           2011 staring in  when the project was ported over:
+           2011-2016 Canonical Ltd.
+License: Expat
+
+Files: vendor/go.yaml.in/yaml/v3/apic.go
+       vendor/go.yaml.in/yaml/v3/emitterc.go
+       vendor/go.yaml.in/yaml/v3/parserc.go
+       vendor/go.yaml.in/yaml/v3/readerc.go
+       vendor/go.yaml.in/yaml/v3/scannerc.go
+       vendor/go.yaml.in/yaml/v3/writerc.go
+       vendor/go.yaml.in/yaml/v3/yamlh.go
+       vendor/go.yaml.in/yaml/v3/yamlprivateh.go
+Copyright: 2006-2010 Kirill Simonov
+           2011-2019 Canonical Ltd
+License: Expat
+
+Files: vendor/go.yaml.in/yaml/v3/decode.go
+       vendor/go.yaml.in/yaml/v3/encode.go
+       vendor/go.yaml.in/yaml/v3/resolve.go
+       vendor/go.yaml.in/yaml/v3/sorter.go
+       vendor/go.yaml.in/yaml/v3/yaml.go
+       vendor/go.yaml.in/yaml/v3/NOTICE
+Copyright: 2011-2019 Canonical Ltd
+License: Apache-2.0
+
+Files: vendor/golang.org/*
+Copyright: 2009-2026 The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
+Copyright: 2019 The Go Authors.
+License: OpenSSL
+
+Files: vendor/google.golang.org/genproto/*
+Copyright: 2026 Google LLC
+License: Apache-2.0
 
 Files: vendor/google.golang.org/grpc/*
-Copyright: 2014-2020 gRPC authors.
+Copyright: 2014-2026 The gRPC Authors
 License: Apache-2.0
+
+Files: vendor/google.golang.org/grpc/CONTRIBUTING.md
+Copyright: message*
+License: Apache-2.0
+
+Files: vendor/google.golang.org/protobuf/*
+Copyright: 2018-2025 The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/google.golang.org/protobuf/types/descriptorpb/*
+Copyright: 2008 Google Inc.
+License: BSD-3-clause
+
+Files: vendor/google.golang.org/protobuf/types/gofeaturespb/*
+Copyright: 2023 Google Inc.
+License: BSD-3-clause
+
+Files: vendor/google.golang.org/protobuf/types/known/*
+Copyright: 2008 Google Inc.
+License: BSD-3-clause
+
+Files: vendor/google.golang.org/protobuf/types/pluginpb/*
+Copyright: 2008 Google Inc.
+License: BSD-3-clause
 
 Files: vendor/gopkg.in/ini.v1/*
-Copyright: 2014-2019 Unknwon.
+Copyright: 2014-2019 Unknwon
 License: Apache-2.0
 
-Files: vendor/gopkg.in/yaml.v*/*
-Copyright: 2011-2019 Canonical Ltd.
-License: Apache-2.0
+Files: vendor/gopkg.in/yaml.v3/*
+Copyright: 2006-2011 Kirill Simonov
+           2011 staring in  when the project was ported over:
+           2011-2016 Canonical Ltd.
+License: Apache-2.0 or Expat
 
 Files: vendor/gopkg.in/yaml.v3/apic.go
        vendor/gopkg.in/yaml.v3/emitterc.go
@@ -153,126 +427,294 @@ Files: vendor/gopkg.in/yaml.v3/apic.go
        vendor/gopkg.in/yaml.v3/writerc.go
        vendor/gopkg.in/yaml.v3/yamlh.go
        vendor/gopkg.in/yaml.v3/yamlprivateh.go
-Copyright: 2011-2019 Canonical Ltd.
-           2006-2011 Kirill Simonov
-License: MIT
+Copyright: 2006-2010 Kirill Simonov
+           2011-2019 Canonical Ltd
+License: Expat
 
-Files: vendor/github.com/alecthomas/chroma/*
-Copyright: 2017 Alec Thomas
-License: MIT
-
-Files: vendor/github.com/atotto/clipboard/*
-Copyright: 2013 Ato Araki.
-License: BSD-3
-
-Files: vendor/github.com/aymanbagabas/go-osc52/*
-Copyright: 2022 Ayman Bagabas
-License: MIT
-
-Files: vendor/github.com/aymerick/douceur/*
-Copyright: 2015 Aymerick JEHANNE
-License: MIT
-
-Files: vendor/github.com/charmbracelet/*
-Copyright: 2019-2022 Charmbracelet, Inc
-License: MIT
-
-Files: vendor/github.com/containerd/console/*
-Copyright: The containerd Authors.
+Files: vendor/gopkg.in/yaml.v3/decode.go
+       vendor/gopkg.in/yaml.v3/encode.go
+       vendor/gopkg.in/yaml.v3/resolve.go
+       vendor/gopkg.in/yaml.v3/sorter.go
+       vendor/gopkg.in/yaml.v3/yaml.go
+       vendor/gopkg.in/yaml.v3/NOTICE
+Copyright: 2011-2019 Canonical Ltd
 License: Apache-2.0
 
-Files: vendor/github.com/dlclark/regexp2/*
-Copyright: Doug Clark / Microsoft Corporation
-License: MIT
-
-Files: vendor/github.com/gorilla/css/*
-Copyright: 2013 Gorilla web toolkit
-License: BSD-3
-
-Files: vendor/github.com/kardianos/service/*
-Copyright: 2015 Daniel Theophanes
-License: Zlib
-
-Files: vendor/github.com/lucasb-eyer/go-colorful/*
-Copyright: 2013 Lucas Beyer
-License: MIT
-
-Files: vendor/github.com/microcosm-cc/bluemonday/*
-Copyright: 2014 David Kitchen <david@buro9.com>
-License: BSD-3
-
-Files: vendor/github.com/muesli/*
-Copyright: 2019-2022 Christian Muehlhaeuser
-License: MIT
-
-Files: vendor/github.com/muesli/cancelreader/*
-Copyright: 2022 Erik Geiser and Christian Muehlhaeuser
-License: MIT
-
-Files: vendor/github.com/olekukonko/tablewriter/*
-Copyright: 2014 Oleku Konko
-License: MIT
-
-Files: vendor/github.com/rivo/uniseg/*
-Copyright: 2019 Oliver Kuederle
-License: MIT
-
-Files: vendor/github.com/yuin/*
-Copyright: 2019-2020 Yusuke Inuzuka
-License: MIT
-
-Files: vendor/github.com/ubuntu/decorate/*
-Copyright: Canonical
-License: MIT
-
-Files: internal/policies/certificate/python/vendor_samba/*
-Copyright: 2021 David Mulder <dmulder@suse.com>
-License: GPL-3+
+# License texts
 
 License: Apache-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ Apache License
+ Version 2.0, January 2004
+ http://www.apache.org/licenses/
+ .
+ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ .
+ 1. Definitions.
+ .
+ "License" shall mean the terms and conditions for use, reproduction, and
+ distribution as defined by Sections 1 through 9 of this document.
+ .
+ "Licensor" shall mean the copyright owner or entity authorized by the copyright
+ owner that is granting the License.
+ .
+ "Legal Entity" shall mean the union of the acting entity and all other entities
+ that control, are controlled by, or are under common control with that entity.
+ For the purposes of this definition, "control" means (i) the power, direct or
+ indirect, to cause the direction or management of such entity, whether by
+ contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+ outstanding shares, or (iii) beneficial ownership of such entity.
+ .
+ "You" (or "Your") shall mean an individual or Legal Entity exercising
+ permissions granted by this License.
+ .
+ "Source" form shall mean the preferred form for making modifications, including
+ but not limited to software source code, documentation source, and configuration
+ files.
+ .
+ "Object" form shall mean any form resulting from mechanical transformation or
+ translation of a Source form, including but not limited to compiled object code,
+ generated documentation, and conversions to other media types.
+ .
+ "Work" shall mean the work of authorship, whether in Source or Object form, made
+ available under the License, as indicated by a copyright notice that is included
+ in or attached to the work (an example is provided in the Appendix below).
+ .
+ "Derivative Works" shall mean any work, whether in Source or Object form, that
+ is based on (or derived from) the Work and for which the editorial revisions,
+ annotations, elaborations, or other modifications represent, as a whole, an
+ original work of authorship. For the purposes of this License, Derivative Works
+ shall not include works that remain separable from, or merely link (or bind by
+ name) to the interfaces of, the Work and Derivative Works thereof.
+ .
+ "Contribution" shall mean any work of authorship, including the original version
+ of the Work and any modifications or additions to that Work or Derivative Works
+ thereof, that is intentionally submitted to Licensor for inclusion in the Work
+ by the copyright owner or by an individual or Legal Entity authorized to submit
+ on behalf of the copyright owner. For the purposes of this definition,
+ "submitted" means any form of electronic, verbal, or written communication sent
+ to the Licensor or its representatives, including but not limited to
+ communication on electronic mailing lists, source code control systems, and
+ issue tracking systems that are managed by, or on behalf of, the Licensor for
+ the purpose of discussing and improving the Work, but excluding communication
+ that is conspicuously marked or otherwise designated in writing by the copyright
+ owner as "Not a Contribution."
+ .
+ "Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+ of whom a Contribution has been received by Licensor and subsequently
+ incorporated within the Work.
+ .
+ 2. Grant of Copyright License.
+ .
+ Subject to the terms and conditions of this License, each Contributor hereby
+ grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+ irrevocable copyright license to reproduce, prepare Derivative Works of,
+ publicly display, publicly perform, sublicense, and distribute the Work and such
+ Derivative Works in Source or Object form.
+ .
+ 3. Grant of Patent License.
+ .
+ Subject to the terms and conditions of this License, each Contributor hereby
+ grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+ irrevocable (except as stated in this section) patent license to make, have
+ made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+ such license applies only to those patent claims licensable by such Contributor
+ that are necessarily infringed by their Contribution(s) alone or by combination
+ of their Contribution(s) with the Work to which such Contribution(s) was
+ submitted. If You institute patent litigation against any entity (including a
+ cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+ Contribution incorporated within the Work constitutes direct or contributory
+ patent infringement, then any patent licenses granted to You under this License
+ for that Work shall terminate as of the date such litigation is filed.
+ .
+ 4. Redistribution.
+ .
+ You may reproduce and distribute copies of the Work or Derivative Works thereof
+ in any medium, with or without modifications, and in Source or Object form,
+ provided that You meet the following conditions:
+ .
+ You must give any other recipients of the Work or Derivative Works a copy of
+ this License; and
+ You must cause any modified files to carry prominent notices stating that You
+ changed the files; and
+ You must retain, in the Source form of any Derivative Works that You distribute,
+ all copyright, patent, trademark, and attribution notices from the Source form
+ of the Work, excluding those notices that do not pertain to any part of the
+ Derivative Works; and
+ If the Work includes a "NOTICE" text file as part of its distribution, then any
+ Derivative Works that You distribute must include a readable copy of the
+ attribution notices contained within such NOTICE file, excluding those notices
+ that do not pertain to any part of the Derivative Works, in at least one of the
+ following places: within a NOTICE text file distributed as part of the
+ Derivative Works; within the Source form or documentation, if provided along
+ with the Derivative Works; or, within a display generated by the Derivative
+ Works, if and wherever such third-party notices normally appear. The contents of
+ the NOTICE file are for informational purposes only and do not modify the
+ License. You may add Your own attribution notices within Derivative Works that
+ You distribute, alongside or as an addendum to the NOTICE text from the Work,
+ provided that such additional attribution notices cannot be construed as
+ modifying the License.
+ You may add Your own copyright statement to Your modifications and may provide
+ additional or different license terms and conditions for use, reproduction, or
+ distribution of Your modifications, or for any such Derivative Works as a whole,
+ provided Your use, reproduction, and distribution of the Work otherwise complies
+ with the conditions stated in this License.
+ .
+ 5. Submission of Contributions.
+ .
+ Unless You explicitly state otherwise, any Contribution intentionally submitted
+ for inclusion in the Work by You to the Licensor shall be under the terms and
+ conditions of this License, without any additional terms or conditions.
+ Notwithstanding the above, nothing herein shall supersede or modify the terms of
+ any separate license agreement you may have executed with Licensor regarding
+ such Contributions.
+ .
+ 6. Trademarks.
+ .
+ This License does not grant permission to use the trade names, trademarks,
+ service marks, or product names of the Licensor, except as required for
+ reasonable and customary use in describing the origin of the Work and
+ reproducing the content of the NOTICE file.
+ .
+ 7. Disclaimer of Warranty.
+ .
+ Unless required by applicable law or agreed to in writing, Licensor provides the
+ Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ including, without limitation, any warranties or conditions of TITLE,
+ NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+ solely responsible for determining the appropriateness of using or
+ redistributing the Work and assume any risks associated with Your exercise of
+ permissions under this License.
+ .
+ 8. Limitation of Liability.
+ .
+ In no event and under no legal theory, whether in tort (including negligence),
+ contract, or otherwise, unless required by applicable law (such as deliberate
+ and grossly negligent acts) or agreed to in writing, shall any Contributor be
+ liable to You for damages, including any direct, indirect, special, incidental,
+ or consequential damages of any character arising as a result of this License or
+ out of the use or inability to use the Work (including but not limited to
+ damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+ any and all other commercial damages or losses), even if such Contributor has
+ been advised of the possibility of such damages.
+ .
+ 9. Accepting Warranty or Additional Liability.
+ .
+ While redistributing the Work or Derivative Works thereof, You may choose to
+ offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+ other liability obligations and/or rights consistent with this License. However,
+ in accepting such obligations, You may act only on Your own behalf and on Your
+ sole responsibility, not on behalf of any other Contributor, and only if You
+ agree to indemnify, defend, and hold each Contributor harmless for any liability
+ incurred by, or claims asserted against, such Contributor by reason of your
+ accepting any such warranty or additional liability.
+ .
+ END OF TERMS AND CONDITIONS
+ .
+ APPENDIX: How to apply the Apache License to your work
+ .
+ To apply the Apache License to your work, attach the following boilerplate
+ notice, with the fields enclosed by brackets "[]" replaced with your own
+ identifying information. (Don't include the brackets!) The text should be
+ enclosed in the appropriate comment syntax for the file format. We also
+ recommend that a file or class name and description of purpose be included on
+ the same "printed page" as the copyright notice for easier identification within
+ third-party archives.
+ .
+    Copyright [yyyy] [name of copyright owner]
+ .
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+ .
+      http://www.apache.org/licenses/LICENSE-2.0
+ .
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
-License: BSD-2
+License: BSD-2-clause
+ All rights reserved.
+ .
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
  .
-  1. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD-3
+License: BSD-3-clause
+ .
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
  met:
-   * Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-     copyright notice, this list of conditions and the following disclaimer
-     in the documentation and/or other materials provided with the
-     distribution.
-   * Neither the name of Google Inc., Jonas Obrist nor the names of its
-     contributors may be used to endorse or promote products derived from
-     this software without specific prior written permission.
-
-License: GPL-3+
- This program is free software: you can redistribute it and/or modify it
- under the terms of the GNU General Public License as published by the
- Free Software Foundation, either version 3 of the License, or (at your
- option) any later version.
  .
- This program is distributed in the hope that it will be useful, but
- WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- Public License for more details.
+    * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the following disclaimer
+ in the documentation and/or other materials provided with the
+ distribution.
+    * Neither the name of @atotto. nor the names of its
+ contributors may be used to endorse or promote products derived from
+ this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: Expat
+ MIT License
+ .
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
 
 License: ISC
+ ISC License
+ .
+ .
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
@@ -285,97 +727,23 @@ License: ISC
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-License: MIT
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
-
-License: MPL-2.0
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at http://mozilla.org/MPL/2.0/.
- Comment:
-  On Debian systems, the complete text of the Mozilla Public License can
-  be found in "/usr/share/common-licenses/MPL-2.0".
-
 License: Zlib
+ .
  This software is provided 'as-is', without any express or implied
- warranty.  In no event will the authors be held liable for any damages
+ warranty. In no event will the authors be held liable for any damages
  arising from the use of this software.
  .
  Permission is granted to anyone to use this software for any purpose,
  including commercial applications, and to alter it and redistribute it
  freely, subject to the following restrictions:
  .
- 1. The origin of this software must not be misrepresented; you must not
+    1. The origin of this software must not be misrepresented; you must not
     claim that you wrote the original software. If you use this software
     in a product, an acknowledgment in the product documentation would be
     appreciated but is not required.
- 2. Altered source versions must be plainly marked as such, and must not be
+ .
+    2. Altered source versions must be plainly marked as such, and must not be
     misrepresented as being the original software.
- 3. This notice may not be removed or altered from any source distribution.
  .
- Jean-loup Gailly        Mark Adler
- jloup@gzip.org          madler@alumni.caltech.edu
-
-License: Unicode
- UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
- .
- See Terms of Use <https://www.unicode.org/copyright.html>
- for definitions of Unicode Inc.’s Data Files and Software.
- .
- NOTICE TO USER: Carefully read the following legal agreement.
- BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
- DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
- YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
- TERMS AND CONDITIONS OF THIS AGREEMENT.
- IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
- THE DATA FILES OR SOFTWARE.
- .
- COPYRIGHT AND PERMISSION NOTICE
- .
- Copyright © 1991-2022 Unicode, Inc. All rights reserved.
- Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
- .
- Permission is hereby granted, free of charge, to any person obtaining
- a copy of the Unicode data files and any associated documentation
- (the "Data Files") or Unicode software and any associated documentation
- (the "Software") to deal in the Data Files or Software
- without restriction, including without limitation the rights to use,
- copy, modify, merge, publish, distribute, and/or sell copies of
- the Data Files or Software, and to permit persons to whom the Data Files
- or Software are furnished to do so, provided that either
- (a) this copyright and permission notice appear with all copies
- of the Data Files or Software, or
- (b) this copyright and permission notice appear in associated
- Documentation.
- .
- THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
- ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
- WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- NONINFRINGEMENT OF THIRD PARTY RIGHTS.
- IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
- NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
- DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
- DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- PERFORMANCE OF THE DATA FILES OR SOFTWARE.
- .
- Except as contained in this notice, the name of a copyright holder
- shall not be used in advertising or otherwise to promote the sale,
- use or other dealings in these Data Files or Software without prior
- written authorization of the copyright holder.
+    3. This notice may not be removed or altered from any source
+    distribution.


### PR DESCRIPTION
After running the tool provided by https://github.com/canonical/dep5-vendor-gen, our copyright file had a lot of issues that were fixed and asserted by running lrc.