### PR TITLE
docs: stop promising a post-merge refresh that no longer happens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,12 @@ go generate -x -tags=tools ./pam      # PAM module in generated/lib/security/
 Other packages contain targeted `go:generate` directives. Do not hand-edit
 generated protobuf files or artifacts under `generated/`. Do not directly edit
 generated reference documentation; change its Go or YAML source instead.
-`CONTRIBUTING.md` documents which generated documentation is refreshed after
-merge. In particular, do not include post-merge updates to `po/`, `README.md`,
-or generated documentation in a routine pull request.
+Only policy definitions are refreshed automatically after merge, so do not include
+changes to `policies/` and `docs/reference/policies/` in routine pull requests. Every
+other generated file must be regenerated and committed after any change that
+invalidates it: in particular, a change to a command or a flag has to include
+the regenerated `docs/reference/*-cli.md`. The freshness check ignores these
+files and no post-merge job updates them.
 
 When changing dependencies, update `go.mod` and `go.sum` (for example with
 `go mod tidy`). Do not create or commit a `vendor/` directory: it is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,7 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 
 > PRs will trigger unit and integration tests with and without race detection, linting and formatting validations, static and security checks, freshness of generated files verification. All the tests must pass before merging in main branch.
 
-Once merged to the main branch, `po` files, `README.md` with the command line reference and any documentation change will be automatically updated. Those are thus not necessary in the pull request itself to minimize diff review.
-
+Policy definitions and their reference documentation are refreshed automatically once merged to the main branch, so you don't need to include updates to `policies/` and `docs/reference/policies/` in your pull request.
 ## Contributing to the documentation
 
 You can also contribute to the documentation. It uses [GitHub Markdown Format](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github).
@@ -71,7 +70,7 @@ an edit button for making small changes, such as fixing typos.
 > Much of the reference documentation in `/docs/reference/` is auto-generated.
 > Editing the content of these files requires modifying `.go` and `.yaml` files found elsewhere in the repo.
 > Some references are generated using `dconf` keys from upstream packages and cannot be edited.
-> Changes made directly to reference files will be overwritten in the automation process.
+> Changes made directly to reference files will be overwritten the next time the file is generated.
 > If you want to propose a change to a reference page please make your edits in the relevant source files 
 > or contact someone on the ADSys team if you are uncertain how to do so.
 


### PR DESCRIPTION
`CONTRIBUTING.md` tells contributors that `po` files, `README.md` and the command line reference are updated automatically once merged, and that they are "thus not necessary in the pull request itself". That stopped being true in 2023.

## Evidence

Only two workflows auto-commit anything: `patch-vendored-samba.yaml` and `policy-builds.yaml`. The latter stages `git add policies/ docs/reference/policies/` — policy definitions only.

Last automated refresh per path on `main`:

| Path | Last automated refresh |
| --- | --- |
| `docs/reference/policies/` | 2026-07-17 — still running |
| `README.md` | 2023-07-31, "Auto update readme files" |
| `po/` | 2023-08-02, "Auto update po files" |
| `docs/reference/adsysctl-cli.md` | never — a single manual commit, 2023-10-24 |

## Why this bites

Nothing contradicts the stale advice. `qa.yaml` passes `generate-diff-paths-to-ignore: po/* docs/**/*.md README.md` to the code-sanity action, so the freshness check skips exactly these paths. A contributor who follows CONTRIBUTING.md gets a green PR and a published reference that never mentions their command.

`main` regenerates dirty today: `go generate ./cmd/adsysd` produces 37 lines of missing content (`adsysctl policy debug ticket-path`, `--gpo-list-timeout`).

## What this changes

Documentation only — no behavior change. States which artifacts are genuinely automated, and makes explicit that a change to a command or flag must commit its own regenerated `docs/reference/*-cli.md`. `AGENTS.md` carried the same assumption and is corrected alongside.

Restoring the automation would be the better long-term fix and is worth a separate issue; until someone does, the docs should describe the repository as it is.
