### PR TITLE
Bump Go toolchain to 1.25.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/adsys
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
Fixes vulnerabilities:

Vulnerability 1: GO-2026-6218
      Avoid quadratic complexity in resolvePath in net/url
    More info: https://pkg.go.dev/vuln/GO-2026-6218
    Standard library
      Found in: net/url@go1.25.12
      Fixed in: net/url@go1.25.13

Vulnerability 2: GO-2026-6090
      Limit handshake messages we are willing to accept post-handshake in
      crypto/tls
    More info: https://pkg.go.dev/vuln/GO-2026-6090
    Standard library
      Found in: crypto/tls@go1.25.12
      Fixed in: crypto/tls@go1.25.13

Vulnerability 3: GO-2026-6088
      Add recursion depth guard during decode in encoding/xml
    More info: https://pkg.go.dev/vuln/GO-2026-6088
    Standard library
      Found in: encoding/xml@go1.25.12
      Fixed in: encoding/xml@go1.25.13

 Vulnerability 4: GO-2026-5972
      Enforce maximum recursion depth in encoding/asn1
    More info: https://pkg.go.dev/vuln/GO-2026-5972
    Standard library
      Found in: encoding/asn1@go1.25.12
      Fixed in: encoding/asn1@go1.25.13