### PR TITLE
certificate: use GSSAPI seal outside TLS during bootstrap

### DIFF
--- a/internal/policies/certificate/gssapi.go
+++ b/internal/policies/certificate/gssapi.go
@@ -225,12 +225,13 @@ func (g *gssapiClient) processAPREP(token []byte) ([]byte, bool, error) {
 //  1. Unwrap the server's GSSAPI wrap token to extract the 4-byte SASL payload
 //     describing supported security layers and max buffer size.
 //  2. Build a response selecting auth-only on a verified TLS connection, or
-//     confidentiality during first-use bootstrap.
+//     confidentiality during first-use bootstrap over plain LDAP.
 //  3. Wrap the response as an integrity-only GSSAPI wrap token.
 //
-// The confidentiality layer is mandatory when StartTLS could not be chained
-// to a configured trust anchor. This prevents a CBT-disabled DC from being
-// used as a GSSAPI relay during first-use CA discovery.
+// The confidentiality layer is mandatory when the DC certificate could not be
+// chained to a configured trust anchor. The bootstrap connection is made
+// without TLS so Active Directory applies the negotiated SASL layer, preventing
+// a GSSAPI relay during first-use CA discovery.
 func (g *gssapiClient) NegotiateSaslAuth(token []byte, authzid string) ([]byte, error) {
 	if !g.sequenceReady {
 		return nil, fmt.Errorf("GSSAPI sequence state was not established by AP-REQ/AP-REP")

--- a/internal/policies/certificate/ldap.go
+++ b/internal/policies/certificate/ldap.go
@@ -121,9 +121,10 @@ type kerberosLDAPBindFunc func(context.Context, *ldap.Conn, string, string, []by
 // addition to the system trust store) when verifying the DC's StartTLS cert.
 //
 // During first use, when the DC certificate cannot yet be chained to a
-// configured root, LDAP protocol data is additionally protected by the
-// Kerberos GSSAPI confidentiality layer. Unknown issuers are never accepted
-// after adsys-managed trust has been configured.
+// configured root, the connector uses StartTLS only to inspect the certificate,
+// then reconnects without TLS and protects LDAP protocol data with the Kerberos
+// GSSAPI confidentiality layer. Unknown issuers are never accepted after
+// adsys-managed trust has been configured.
 func newKerberosLDAPConnector(krb5CacheDir, globalTrustDir string, allowBootstrap bool) LDAPConnector {
 	return &kerberosLDAPConnector{
 		krb5CacheDir:   krb5CacheDir,
@@ -255,26 +256,36 @@ func (c *deadlineLDAPClient) Close() error {
 	return c.conn.Close()
 }
 
+func dialLDAPCandidate(ctx context.Context, address string) (net.Conn, func(), error) {
+	dialer := &net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, nil, err
+	}
+	stopContextInterrupt := interruptConnectionOnDone(ctx, conn)
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			stopContextInterrupt()
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("setting LDAP candidate deadline: %w", err)
+		}
+	}
+	return conn, stopContextInterrupt, nil
+}
+
 func (c kerberosLDAPConnector) connectCandidate(ctx context.Context, candidate ldapServerCandidate) (LDAPClient, error) {
 	log.Debugf(ctx, "Connecting to LDAP server: %s", candidate.address)
-	dialer := &net.Dialer{}
-	rawConn, err := dialer.DialContext(ctx, "tcp", candidate.address)
+	rawConn, stopContextInterrupt, err := dialLDAPCandidate(ctx, candidate.address)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to LDAP server %s: %w", candidate.address, err)
 	}
 	closeOnError := true
 	defer func() {
+		stopContextInterrupt()
 		if closeOnError {
 			_ = rawConn.Close()
 		}
 	}()
-	stopContextInterrupt := interruptConnectionOnDone(ctx, rawConn)
-	defer stopContextInterrupt()
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := rawConn.SetDeadline(deadline); err != nil {
-			return nil, fmt.Errorf("setting LDAP candidate deadline: %w", err)
-		}
-	}
 
 	if err := requestStartTLS(rawConn); err != nil {
 		if ctx.Err() != nil {
@@ -292,19 +303,41 @@ func (c kerberosLDAPConnector) connectCandidate(ctx context.Context, candidate l
 		return nil, fmt.Errorf("TLS handshake with LDAP server %s: %w", candidate.host, err)
 	}
 
-	transport := newSASLSecurityConn(tlsConn)
-	conn := ldap.NewConn(transport, true)
-	conn.SetTimeout(ldapCandidateTimeout)
-	conn.Start()
-	closeOnError = false
-
 	tlsState := tlsConn.ConnectionState()
 	if len(tlsState.PeerCertificates) == 0 {
-		_ = conn.Close()
 		return nil, fmt.Errorf("LDAP TLS server %s presented no certificate", candidate.host)
 	}
-	channelBinding := tlsServerEndPointChannelBinding(tlsState.PeerCertificates[0])
 	requireConfidentiality := trustState.bootstrap.Load()
+	var (
+		channelBinding []byte
+		transportConn  net.Conn = tlsConn
+		isTLS                   = true
+	)
+	if requireConfidentiality {
+		// Active Directory does not apply a negotiated SASL security layer to
+		// a connection already protected by TLS. Reconnect to the same DC and
+		// let Kerberos mutual authentication and confidentiality protect the
+		// bootstrap LDAP exchange.
+		stopContextInterrupt()
+		_ = tlsConn.Close()
+		bootstrapConn, stopBootstrapInterrupt, err := dialLDAPCandidate(ctx, candidate.address)
+		if err != nil {
+			return nil, fmt.Errorf("reconnecting to LDAP server %s for GSSAPI bootstrap: %w", candidate.address, err)
+		}
+		rawConn = bootstrapConn
+		stopContextInterrupt = stopBootstrapInterrupt
+		transportConn = rawConn
+		isTLS = false
+		log.Debugf(ctx, "Using GSSAPI confidentiality without TLS for LDAP bootstrap to %s", candidate.host)
+	} else {
+		channelBinding = tlsServerEndPointChannelBinding(tlsState.PeerCertificates[0])
+	}
+
+	transport := newSASLSecurityConn(transportConn)
+	conn := ldap.NewConn(transport, isTLS)
+	conn.SetTimeout(ldapCandidateTimeout)
+	conn.Start()
+
 	bind := c.bind
 	if bind == nil {
 		bind = gssapiBindWithOptions
@@ -332,6 +365,7 @@ func (c kerberosLDAPConnector) connectCandidate(ctx context.Context, candidate l
 		_ = conn.Close()
 		return nil, fmt.Errorf("clearing LDAP candidate deadline: %w", err)
 	}
+	closeOnError = false
 	log.Debugf(ctx, "LDAP connection established and authenticated to %s", candidate.host)
 	return &deadlineLDAPClient{conn: conn, transport: transport, timeout: ldapCandidateTimeout}, nil
 }
@@ -768,9 +802,9 @@ func verifyPeerCertificateWithTrustState(server, globalTrustDir string, allowBoo
 			// store yet (adsys installs it later in this same run), so the DC
 			// certificate cannot chain to a trusted root. When bootstrapping is
 			// allowed and no managed trust exists, tolerate only this "unknown
-			// authority" case. The connector requires GSSAPI confidentiality
-			// for every subsequent LDAP message on this connection. Any other
-			// failure remains fatal.
+			// authority" case. The connector then reconnects without TLS and
+			// requires GSSAPI confidentiality for the bootstrap LDAP exchange.
+			// Any other failure remains fatal.
 			var unknownAuthority x509.UnknownAuthorityError
 			if !allowBootstrap || managedTrustExists || !errors.As(err, &unknownAuthority) {
 				return fmt.Errorf("server certificate verification failed: %w", err)
@@ -779,7 +813,7 @@ func verifyPeerCertificateWithTrustState(server, globalTrustDir string, allowBoo
 				return fmt.Errorf("server certificate verification failed: %w", hostErr)
 			}
 			log.Warningf(context.Background(),
-				"Server certificate for %q is not signed by an installed CA yet; requiring GSSAPI confidentiality for bootstrap enrollment: %v",
+				"Server certificate for %q is not signed by an installed CA yet; using GSSAPI confidentiality for bootstrap enrollment: %v",
 				tlsServerName(server), err)
 			if state != nil {
 				state.bootstrap.Store(true)

--- a/internal/policies/certificate/ldap_test.go
+++ b/internal/policies/certificate/ldap_test.go
@@ -1174,6 +1174,132 @@ func TestReadBERElementRejectsTruncation(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCandidateTransportMatchesCertificateTrust(t *testing.T) {
+	tests := map[string]struct {
+		bootstrap bool
+	}{
+		"untrusted certificate uses plain LDAP with GSSAPI confidentiality": {
+			bootstrap: true,
+		},
+		"trusted certificate keeps StartTLS and channel binding": {},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			serverCertificate := generateLDAPServerCertificate(t)
+			trustDir := t.TempDir()
+			if !tc.bootstrap {
+				certificatePEM := pem.EncodeToMemory(&pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: serverCertificate.Certificate[0],
+				})
+				require.NoError(t, os.WriteFile(filepath.Join(trustDir, "root.crt"), certificatePEM, 0600))
+			}
+			address, serverErr := runLDAPTransportServer(t, serverCertificate, tc.bootstrap)
+			host, _, err := net.SplitHostPort(address)
+			require.NoError(t, err)
+
+			var (
+				gotChannelBinding         []byte
+				gotRequireConfidentiality bool
+				gotTLS                    bool
+			)
+			connector := &kerberosLDAPConnector{
+				globalTrustDir: trustDir,
+				allowBootstrap: true,
+				bind: func(_ context.Context, _ *ldap.Conn, _, _ string, channelBinding []byte, requireConfidentiality bool, transport *saslSecurityConn) error {
+					gotChannelBinding = append([]byte(nil), channelBinding...)
+					gotRequireConfidentiality = requireConfidentiality
+					_, gotTLS = transport.Conn.(*tls.Conn)
+					if !requireConfidentiality {
+						return nil
+					}
+					layer, err := newSASLSecurityLayer(testKey(), false, saslReceiveBufferSize, 0, 0)
+					if err != nil {
+						return err
+					}
+					if err := transport.armSecurityLayer(layer); err != nil {
+						layer.Close()
+						return err
+					}
+					transport.observeRawBindResponse([]byte{0x30, 0x00})
+					return nil
+				},
+			}
+			client, err := connector.connectCandidate(context.Background(), ldapServerCandidate{address: address, host: host})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.bootstrap, gotRequireConfidentiality)
+			assert.Equal(t, !tc.bootstrap, gotTLS)
+			if tc.bootstrap {
+				assert.Empty(t, gotChannelBinding)
+			} else {
+				assert.NotEmpty(t, gotChannelBinding)
+			}
+			require.NoError(t, client.Close())
+			require.NoError(t, <-serverErr)
+		})
+	}
+}
+
+func runLDAPTransportServer(t *testing.T, certificate tls.Certificate, expectBootstrap bool) (address string, result <-chan error) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverResult := make(chan error, 1)
+	go func() {
+		rawConn, err := listener.Accept()
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		defer rawConn.Close()
+		tag, _, err := readBERElement(rawConn)
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		if tag != 0x30 {
+			serverResult <- fmt.Errorf("unexpected StartTLS request tag 0x%02x", tag)
+			return
+		}
+		if err := writeAll(rawConn, []byte{0x30, 0x0c, 0x02, 0x01, 0x01, 0x78, 0x07, 0x0a, 0x01, 0x00, 0x04, 0x00, 0x04, 0x00}); err != nil {
+			serverResult <- err
+			return
+		}
+		tlsConn := tls.Server(rawConn, &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{certificate},
+		})
+		if err := tlsConn.Handshake(); err != nil {
+			serverResult <- err
+			return
+		}
+		if _, err := io.Copy(io.Discard, tlsConn); err != nil {
+			serverResult <- err
+			return
+		}
+		if !expectBootstrap {
+			serverResult <- nil
+			return
+		}
+
+		bootstrapConn, err := listener.Accept()
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		defer bootstrapConn.Close()
+		if _, err := io.Copy(io.Discard, bootstrapConn); err != nil {
+			serverResult <- err
+			return
+		}
+		serverResult <- nil
+	}()
+	return listener.Addr().String(), serverResult
+}
+
 func TestCandidateSetupCancellation(t *testing.T) {
 	tests := map[string]bool{
 		"stalled StartTLS response": true,


### PR DESCRIPTION
## Description

Fresh certificate enrollment used StartTLS and then requested a GSSAPI confidentiality layer when the domain controller certificate was not trusted yet. Active Directory does not apply SASL security layers to an LDAP connection already protected by TLS, so the next plaintext LDAP response was interpreted as a SASL frame and enrollment failed.

Use StartTLS to determine whether the DC certificate is trusted, then reconnect to the same candidate without TLS when first-use bootstrap requires GSSAPI confidentiality. Kerberos mutual authentication and sealing protect the bootstrap exchange. Trusted connections continue to use StartTLS and channel binding.

Regression coverage verifies both transport paths.

## Tests

- `go test ./internal/policies/certificate -count=1`
- `go test -race ./internal/policies/certificate -count=1`
- `go test ./internal/policies/... -count=1`
- `golangci-lint run ./internal/policies/certificate/...`

The Azure/VPN-backed end-to-end suite was not run locally.
