### PR TITLE
ci: pin staticcheck to v0.7.0

### DIFF
--- a/.github/workflows/tics-report.yaml
+++ b/.github/workflows/tics-report.yaml
@@ -29,7 +29,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ env.apt_dependencies }}
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+
+          # We need to pin staticcheck to v0.7.0 while we are in Go 1.25 since newer versions require Go 1.26 or later.
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+
           dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Merge coverage reports


### PR DESCRIPTION
Newer staticcheck versions [require Go >= 1.26](https://github.com/ubuntu/adsys/actions/runs/33355093037/job/99375596297#step:5:659). Since we are bound to Go 1.25 due to archive availability, we need to pin the dependency version to the latest one that still supports Go 1.25.